### PR TITLE
Update TicsPublisher.js

### DIFF
--- a/src/tics/TicsPublisher.js
+++ b/src/tics/TicsPublisher.js
@@ -20,13 +20,39 @@ export class TicsPublisher {
   };
 
   getQualityGateUrlAPI = (explorerUrl) => {
-    let qualityGateUrlAPI = new URL(getTiobeWebBaseUrlFromUrl(ticsConfig.ticsConfiguration) + '/api/public/v1/QualityGateStatus');
-    qualityGateUrlAPI.searchParams.append('project', ticsConfig.projectName);
-    qualityGateUrlAPI.searchParams.append('branch', ticsConfig.branchName);
+    let projectName = (ticsConfig.projectName == 'auto')? this.getItemFromUrl(explorerUrl, 'Project') : ticsConfig.projectName;
+    let clientDataTok = this.getItemFromUrl(explorerUrl, 'ClientData');
+    let qualityGateUrlAPI = new URL(getTiobewebBaseUrlFromGivenUrl(ticsConfig.ticsConfiguration) + '/api/public/v1/QualityGateStatus');
+    
+    qualityGateUrlAPI.searchParams.append('project', projectName);
+    
+    // Branchname is optional, to check if it is set
+    if (ticsConfig.branchName) {
+      qualityGateUrlAPI.searchParams.append('branch', ticsConfig.branchName);
+    }
+    
     qualityGateUrlAPI.searchParams.append('fields', 'details,annotationsApiV1Links');
-    qualityGateUrlAPI.searchParams.append('cdt', this.getSubstring(decodeURIComponent(explorerUrl), 'ClientData(', '),Project'));
+    qualityGateUrlAPI.searchParams.append('cdt', clientDataTok);
 
     return qualityGateUrlAPI.href;
+  };
+  
+  /* 
+    Gets item form URL. Example:
+    Input 0 : https://testlab.tiobe.com/tiobeweb/testlab/Explorer.html#axes=ClientData%2807dZd7R5GmI0xI9lhN18Yg%29%2CProject%28c-demo%29%2CBranch%28main%
+    Input 1 : Project
+    Output : c-demo
+  */
+  getItemFromUrl = (explorerUrl, item) => {
+    let regExpr = new RegExp(`${item}\\((.*?)\\)`);
+    let itemValue = decodeURIComponent(explorerUrl).match(regExpr);
+
+    if (itemValue.length >= 2) {
+      console.log(`Retrieved ${item} value: ${itemValue[1]}`);
+      return itemValue[1];
+    }
+
+    return '';
   };
 
   getQualityGates = async (url) => {

--- a/src/tics/TicsPublisher.js
+++ b/src/tics/TicsPublisher.js
@@ -22,7 +22,7 @@ export class TicsPublisher {
   getQualityGateUrlAPI = (explorerUrl) => {
     let projectName = (ticsConfig.projectName == 'auto')? this.getItemFromUrl(explorerUrl, 'Project') : ticsConfig.projectName;
     let clientDataTok = this.getItemFromUrl(explorerUrl, 'ClientData');
-    let qualityGateUrlAPI = new URL(getTiobewebBaseUrlFromGivenUrl(ticsConfig.ticsConfiguration) + '/api/public/v1/QualityGateStatus');
+    let qualityGateUrlAPI = new URL(getTiobeWebBaseUrlFromUrl(ticsConfig.ticsConfiguration) + '/api/public/v1/QualityGateStatus');
     
     qualityGateUrlAPI.searchParams.append('project', projectName);
     

--- a/src/tics/TicsPublisher.js
+++ b/src/tics/TicsPublisher.js
@@ -37,12 +37,12 @@ export class TicsPublisher {
     return qualityGateUrlAPI.href;
   };
   
-  /* 
-    Gets item form URL. Example:
-    Input 0 : https://testlab.tiobe.com/tiobeweb/testlab/Explorer.html#axes=ClientData%2807dZd7R5GmI0xI9lhN18Yg%29%2CProject%28c-demo%29%2CBranch%28main%
-    Input 1 : Project
-    Output : c-demo
-  */
+  /**
+  * Gets item form URL
+  * @param explorerURL, e.g. https://testlab.tiobe.com/tiobeweb/testlab/Explorer.html#axes=ClientData%2807dZd7R5GmI0xI9lhN18Yg%29%2CProject%28c-demo%29%2CBranch%28main%
+  * @param item, e.g. Project
+  * @returns item value, e.g. c-demo
+  **/
   getItemFromUrl = (explorerUrl, item) => {
     let regExpr = new RegExp(`${item}\\((.*?)\\)`);
     let itemValue = decodeURIComponent(explorerUrl).match(regExpr);


### PR DESCRIPTION
Implemented logic to resolve project "auto" to the actual project name. The Explorer URL is reused for that purpose. The way items are retrieved from the URL was refactored.