### PR TITLE
Added insecure option for curl

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -74,6 +74,9 @@ async function main() {
   }
 }
 
+/**
+ * Configure the action before running the analysis.
+ */
 export function configure() {
   process.removeAllListeners('warning');
   process.on('warning', warning => {

--- a/src/tics/analyzer.ts
+++ b/src/tics/analyzer.ts
@@ -71,14 +71,19 @@ async function getInstallTics() {
   const installTicsUrl = await retrieveInstallTics(githubConfig.runnerOS.toLowerCase());
 
   if (githubConfig.runnerOS === 'Linux') {
-    return `source <(curl -s '${installTicsUrl}') &&`;
+    let trustStrategy = '';
+    if (ticsConfig.trustStrategy === 'self-signed' || ticsConfig.trustStrategy === 'all') {
+      trustStrategy = '--insecure';
+    }
+    return `source <(curl --silent ${trustStrategy} '${installTicsUrl}') &&`;
+  } else {
+    // runnerOS is assumed to be Windows here
+    let trustStrategy = '';
+    if (ticsConfig.trustStrategy === 'self-signed' || ticsConfig.trustStrategy === 'all') {
+      trustStrategy = '[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true};';
+    }
+    return `Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; ${trustStrategy} iex ((New-Object System.Net.WebClient).DownloadString('${installTicsUrl}'))`;
   }
-
-  let trustStrategy = '';
-  if (ticsConfig.trustStrategy === 'self-signed' || ticsConfig.trustStrategy === 'all') {
-    trustStrategy = '[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true};';
-  }
-  return `Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; ${trustStrategy} iex ((New-Object System.Net.WebClient).DownloadString('${installTicsUrl}'))`;
 }
 
 /**

--- a/test/tics/analyzer.test.ts
+++ b/test/tics/analyzer.test.ts
@@ -88,7 +88,7 @@ describe('test multiple types of configuration', () => {
     );
   });
 
-  test('Should call exec with full TiCS command for Linux', async () => {
+  test('Should call exec with full TiCS command for Linux, trustStrategy self-signed', async () => {
     (exec.exec as any).mockResolvedValueOnce(0);
     jest.spyOn(api_helper, 'httpRequest').mockImplementationOnce((): Promise<any> => Promise.resolve({ links: { installTics: 'url' } }));
     const spy = jest.spyOn(exec, 'exec');
@@ -98,6 +98,7 @@ describe('test multiple types of configuration', () => {
     ticsConfig.tmpDir = '/home/ubuntu/test';
     ticsConfig.additionalFlags = '-log 9';
     ticsConfig.installTics = true;
+    ticsConfig.trustStrategy = 'self-signed';
 
     githubConfig.runnerOS = 'Linux';
 
@@ -106,7 +107,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "/bin/bash -c \"source <(curl -s 'http://base.com/url') && TICS @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9\"",
+      "/bin/bash -c \"source <(curl --silent --insecure 'http://base.com/url') && TICS @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -125,6 +126,7 @@ describe('test multiple types of configuration', () => {
     ticsConfig.tmpDir = '/home/ubuntu/test';
     ticsConfig.additionalFlags = '-log 9';
     ticsConfig.installTics = true;
+    ticsConfig.trustStrategy = '';
 
     githubConfig.runnerOS = 'Windows';
 


### PR DESCRIPTION
In version 2.0.0 an option to allow downloads from self-signed certificates was added, this wasn't done for Linux.
Now an optional --insecure has been added to the curl call to allow for this on Linux.