### PR TITLE
Added diagnostic mode for running TICS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # TICS GitHub Action
+
 [![Build](https://github.com/tiobe/tics-github-action/actions/workflows/build.yml/badge.svg)](https://github.com/tiobe/tics-github-action/actions/workflows/build.yml)
 [![CodeQL](https://github.com/tiobe/tics-github-action/actions/workflows/codeql.yml/badge.svg)](https://github.com/tiobe/tics-github-action/actions/workflows/codeql.yml)
 
@@ -77,6 +78,7 @@ The following inputs are available for this action:
 | `hostnameVerification` | Check whether the certificate matches the server. Options are `1`/`true` or `0`/`false`. [Documentation on Client-side SSL/TLS](https://portal.tiobe.com/2022.2/docs/#doc=admin/admin_11_viewer.html%23ssl-wrapper). | false    |
 | `trustStrategy`        | Check the validity of certificates. Options are `all`, `self-signed` or `strict`. [Documentation on Client-side SSL/TLS](https://portal.tiobe.com/2022.2/docs/#doc=admin/admin_11_viewer.html%23ssl-wrapper).        | false    |
 | `installTics`          | Boolean parameter to install TiCS command-line tools on a runner before executing the analysis. If not specified, TiCS should be installed manually on the machine that runs this job.                               | false    |
+| `mode`                 | Set the mode to run the action in. Options are `default` for a normal analysis run and `diagnostic` for a diagnostic testing of the setup.                                                                           | false    |
 | `postAnnotation`       | Show the latest TiCS annotations directly in the GitHub Pull Request review.                                                                                                                                         | false    |
 | `pullRequestApproval`  | Set the plugin to approve or deny a pull request, by default this is true. Options are `true` or `false`.                                                                                                            | false    |
 | `secretsFilter`        | Comma-seperated list of extra secrets to mask in the console output.                                                                                                                                                 | false    |

--- a/action.yaml
+++ b/action.yaml
@@ -55,6 +55,10 @@ inputs:
     description: Boolean parameter to install TICS command-line tools on a runner before executing the analysis.
     required: false
     default: false
+  mode:
+    description: Set the mode to run the action in. Options are `default` for a normal analysis run and `diagnostic` for a diagnostic testing of the setup.
+    required: false
+    default: default
   postAnnotations:
     description: Show the latest TiCS annotations directly in the GitHub Pull Request review.
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -1082,9 +1082,9 @@ async function retrieveInstallTics(os) {
  * @returns string of the command to run TiCS.
  */
 function getTicsCommand(fileListPath) {
-    let execString = 'TICS ';
+    let execString = 'TICS -ide ';
     if (configuration_1.ticsConfig.mode === 'diagnostic') {
-        execString += '-viewer ';
+        execString += '-version ';
     }
     else {
         execString += `@${fileListPath} -viewer `;

--- a/dist/index.js
+++ b/dist/index.js
@@ -835,6 +835,7 @@ async function main() {
     try {
         let analysis;
         if (configuration_1.ticsConfig.mode === 'diagnostic') {
+            logger_1.default.Instance.header('Running action in diagnostic mode');
             analysis = await (0, analyzer_1.runTicsAnalyzer)('');
             if (analysis.statusCode !== 0)
                 logger_1.default.Instance.setFailed('Diagnostic run has failed.');
@@ -976,7 +977,7 @@ let completed;
  * @param fileListPath Path to changedFiles.txt.
  */
 async function runTicsAnalyzer(fileListPath) {
-    logger_1.default.Instance.header(`Analyzing new pull request for project ${configuration_1.ticsConfig.projectName}`);
+    logger_1.default.Instance.header(`Analyzing for project ${configuration_1.ticsConfig.projectName}`);
     const command = await buildRunCommand(fileListPath);
     logger_1.default.Instance.header('Running TiCS');
     logger_1.default.Instance.debug(`With command: ${command}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -46,22 +46,23 @@ exports.ticsConfig = {
     additionalFlags: (0, core_1.getInput)('additionalFlags'),
     branchDir: (0, core_1.getInput)('branchDir'),
     branchName: (0, core_1.getInput)('branchName'),
-    calc: (0, core_1.getInput)('calc'),
-    nocalc: (0, core_1.getInput)('nocalc'),
-    recalc: (0, core_1.getInput)('recalc'),
-    norecalc: (0, core_1.getInput)('norecalc'),
     clientData: (0, core_1.getInput)('clientData'),
     codetype: (0, core_1.getInput)('codetype'),
-    hostnameVerification: (0, core_1.getInput)('hostnameVerification'),
-    trustStrategy: (0, core_1.getInput)('trustStrategy'),
+    calc: (0, core_1.getInput)('calc'),
     excludeMovedFiles: (0, core_1.getBooleanInput)('excludeMovedFiles'),
+    hostnameVerification: (0, core_1.getInput)('hostnameVerification'),
     installTics: (0, core_1.getBooleanInput)('installTics'),
+    mode: (0, core_1.getInput)('mode'),
+    nocalc: (0, core_1.getInput)('nocalc'),
+    norecalc: (0, core_1.getInput)('norecalc'),
     postAnnotations: (0, core_1.getBooleanInput)('postAnnotations'),
+    pullRequestApproval: (0, core_1.getBooleanInput)('pullRequestApproval'),
+    recalc: (0, core_1.getInput)('recalc'),
     ticsAuthToken: (0, core_1.getInput)('ticsAuthToken'),
     tmpDir: (0, core_1.getInput)('tmpDir'),
-    viewerUrl: (0, core_1.getInput)('viewerUrl'),
-    pullRequestApproval: (0, core_1.getBooleanInput)('pullRequestApproval'),
-    secretsFilter: getSecretsFilter((0, core_1.getInput)('secretsFilter'))
+    trustStrategy: (0, core_1.getInput)('trustStrategy'),
+    secretsFilter: getSecretsFilter((0, core_1.getInput)('secretsFilter')),
+    viewerUrl: (0, core_1.getInput)('viewerUrl')
 };
 exports.octokit = (0, github_1.getOctokit)(exports.ticsConfig.githubToken);
 exports.requestInit = { agent: new proxy_agent_1.default(), headers: {} };
@@ -1075,15 +1076,21 @@ async function retrieveInstallTics(os) {
  * @returns string of the command to run TiCS.
  */
 function getTicsCommand(fileListPath) {
-    let execString = 'TICS @' + fileListPath + ' -viewer ';
-    execString += `-project '${configuration_1.ticsConfig.projectName}' `;
-    execString += `-calc ${configuration_1.ticsConfig.calc} `;
-    execString += configuration_1.ticsConfig.nocalc ? `-nocalc ${configuration_1.ticsConfig.nocalc} ` : '';
-    execString += configuration_1.ticsConfig.recalc ? `-recalc ${configuration_1.ticsConfig.recalc} ` : '';
-    execString += configuration_1.ticsConfig.norecalc ? `-norecalc ${configuration_1.ticsConfig.norecalc} ` : '';
-    execString += configuration_1.ticsConfig.codetype ? `-codetype ${configuration_1.ticsConfig.codetype} ` : '';
-    execString += configuration_1.ticsConfig.clientData ? `-cdtoken ${configuration_1.ticsConfig.clientData} ` : '';
-    execString += configuration_1.ticsConfig.tmpDir ? `-tmpdir '${configuration_1.ticsConfig.tmpDir}' ` : '';
+    let execString = 'TICS ';
+    if (configuration_1.ticsConfig.mode === 'diagnostic') {
+        execString += '-viewer ';
+    }
+    else {
+        execString += `@${fileListPath} -viewer `;
+        execString += `-project '${configuration_1.ticsConfig.projectName}' `;
+        execString += `-calc ${configuration_1.ticsConfig.calc} `;
+        execString += configuration_1.ticsConfig.nocalc ? `-nocalc ${configuration_1.ticsConfig.nocalc} ` : '';
+        execString += configuration_1.ticsConfig.recalc ? `-recalc ${configuration_1.ticsConfig.recalc} ` : '';
+        execString += configuration_1.ticsConfig.norecalc ? `-norecalc ${configuration_1.ticsConfig.norecalc} ` : '';
+        execString += configuration_1.ticsConfig.codetype ? `-codetype ${configuration_1.ticsConfig.codetype} ` : '';
+        execString += configuration_1.ticsConfig.clientData ? `-cdtoken ${configuration_1.ticsConfig.clientData} ` : '';
+        execString += configuration_1.ticsConfig.tmpDir ? `-tmpdir '${configuration_1.ticsConfig.tmpDir}' ` : '';
+    }
     execString += configuration_1.ticsConfig.additionalFlags ? configuration_1.ticsConfig.additionalFlags : '';
     // Add TICS debug flag when in debug mode, if this flag was not already set.
     execString += configuration_1.githubConfig.debugger && !execString.includes('-log ') ? ' -log 9' : '';

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -38,22 +38,23 @@ export const ticsConfig = {
   additionalFlags: getInput('additionalFlags'),
   branchDir: getInput('branchDir'),
   branchName: getInput('branchName'),
-  calc: getInput('calc'),
-  nocalc: getInput('nocalc'),
-  recalc: getInput('recalc'),
-  norecalc: getInput('norecalc'),
   clientData: getInput('clientData'),
   codetype: getInput('codetype'),
-  hostnameVerification: getInput('hostnameVerification'),
-  trustStrategy: getInput('trustStrategy'),
+  calc: getInput('calc'),
   excludeMovedFiles: getBooleanInput('excludeMovedFiles'),
+  hostnameVerification: getInput('hostnameVerification'),
   installTics: getBooleanInput('installTics'),
+  mode: getInput('mode'),
+  nocalc: getInput('nocalc'),
+  norecalc: getInput('norecalc'),
   postAnnotations: getBooleanInput('postAnnotations'),
+  pullRequestApproval: getBooleanInput('pullRequestApproval'),
+  recalc: getInput('recalc'),
   ticsAuthToken: getInput('ticsAuthToken'),
   tmpDir: getInput('tmpDir'),
-  viewerUrl: getInput('viewerUrl'),
-  pullRequestApproval: getBooleanInput('pullRequestApproval'),
-  secretsFilter: getSecretsFilter(getInput('secretsFilter'))
+  trustStrategy: getInput('trustStrategy'),
+  secretsFilter: getSecretsFilter(getInput('secretsFilter')),
+  viewerUrl: getInput('viewerUrl')
 };
 
 export const octokit = getOctokit(ticsConfig.githubToken);

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ async function main() {
     let analysis: Analysis | undefined;
 
     if (ticsConfig.mode === 'diagnostic') {
+      Logger.Instance.header('Running action in diagnostic mode');
       analysis = await runTicsAnalyzer('');
       if (analysis.statusCode !== 0) Logger.Instance.setFailed('Diagnostic run has failed.');
     } else {

--- a/src/tics/analyzer.ts
+++ b/src/tics/analyzer.ts
@@ -130,9 +130,9 @@ async function retrieveInstallTics(os: string) {
  * @returns string of the command to run TiCS.
  */
 function getTicsCommand(fileListPath: string) {
-  let execString = 'TICS ';
+  let execString = 'TICS -ide ';
   if (ticsConfig.mode === 'diagnostic') {
-    execString += '-viewer ';
+    execString += '-version ';
   } else {
     execString += `@${fileListPath} -viewer `;
     execString += `-project '${ticsConfig.projectName}' `;

--- a/src/tics/analyzer.ts
+++ b/src/tics/analyzer.ts
@@ -130,15 +130,20 @@ async function retrieveInstallTics(os: string) {
  * @returns string of the command to run TiCS.
  */
 function getTicsCommand(fileListPath: string) {
-  let execString = 'TICS @' + fileListPath + ' -viewer ';
-  execString += `-project '${ticsConfig.projectName}' `;
-  execString += `-calc ${ticsConfig.calc} `;
-  execString += ticsConfig.nocalc ? `-nocalc ${ticsConfig.nocalc} ` : '';
-  execString += ticsConfig.recalc ? `-recalc ${ticsConfig.recalc} ` : '';
-  execString += ticsConfig.norecalc ? `-norecalc ${ticsConfig.norecalc} ` : '';
-  execString += ticsConfig.codetype ? `-codetype ${ticsConfig.codetype} ` : '';
-  execString += ticsConfig.clientData ? `-cdtoken ${ticsConfig.clientData} ` : '';
-  execString += ticsConfig.tmpDir ? `-tmpdir '${ticsConfig.tmpDir}' ` : '';
+  let execString = 'TICS ';
+  if (ticsConfig.mode === 'diagnostic') {
+    execString += '-viewer ';
+  } else {
+    execString += `@${fileListPath} -viewer `;
+    execString += `-project '${ticsConfig.projectName}' `;
+    execString += `-calc ${ticsConfig.calc} `;
+    execString += ticsConfig.nocalc ? `-nocalc ${ticsConfig.nocalc} ` : '';
+    execString += ticsConfig.recalc ? `-recalc ${ticsConfig.recalc} ` : '';
+    execString += ticsConfig.norecalc ? `-norecalc ${ticsConfig.norecalc} ` : '';
+    execString += ticsConfig.codetype ? `-codetype ${ticsConfig.codetype} ` : '';
+    execString += ticsConfig.clientData ? `-cdtoken ${ticsConfig.clientData} ` : '';
+    execString += ticsConfig.tmpDir ? `-tmpdir '${ticsConfig.tmpDir}' ` : '';
+  }
   execString += ticsConfig.additionalFlags ? ticsConfig.additionalFlags : '';
   // Add TICS debug flag when in debug mode, if this flag was not already set.
   execString += githubConfig.debugger && !execString.includes('-log ') ? ' -log 9' : '';

--- a/src/tics/analyzer.ts
+++ b/src/tics/analyzer.ts
@@ -130,7 +130,7 @@ async function retrieveInstallTics(os: string) {
  * @returns string of the command to run TiCS.
  */
 function getTicsCommand(fileListPath: string) {
-  let execString = 'TICS -ide ';
+  let execString = 'TICS -ide github ';
   if (ticsConfig.mode === 'diagnostic') {
     execString += '-version ';
   } else {

--- a/src/tics/analyzer.ts
+++ b/src/tics/analyzer.ts
@@ -14,7 +14,7 @@ let completed: boolean;
  * @param fileListPath Path to changedFiles.txt.
  */
 export async function runTicsAnalyzer(fileListPath: string) {
-  Logger.Instance.header(`Analyzing new pull request for project ${ticsConfig.projectName}`);
+  Logger.Instance.header(`Analyzing for project ${ticsConfig.projectName}`);
 
   const command = await buildRunCommand(fileListPath);
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -14,7 +14,6 @@ import * as posting_annotations from '../src/github/posting/annotations';
 
 import {
   analysisFailedNoUrl,
-  analysisFailedUrl,
   analysisPassed,
   analysisPassedNoUrl,
   analysisPassedNoUrlWarning5057,

--- a/test/main_helper.ts
+++ b/test/main_helper.ts
@@ -69,14 +69,6 @@ export const analysisFailedNoUrl = {
   warningList: []
 };
 
-export const analysisFailedUrl = {
-  completed: false,
-  statusCode: 1,
-  explorerUrl: undefined,
-  errorList: ['Error'],
-  warningList: []
-};
-
 export const analysisPassedNoUrl = {
   completed: true,
   statusCode: 0,

--- a/test/tics/analyzer.test.ts
+++ b/test/tics/analyzer.test.ts
@@ -17,7 +17,7 @@ describe('test multiple types of configuration', () => {
 
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
-    expect(spy).toHaveBeenCalledWith('/bin/bash -c " TICS -ide -version "', [], {
+    expect(spy).toHaveBeenCalledWith('/bin/bash -c " TICS -ide github -version "', [], {
       listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
       silent: true
     });
@@ -34,7 +34,7 @@ describe('test multiple types of configuration', () => {
 
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
-    expect(spy).toHaveBeenCalledWith('/bin/bash -c " TICS -ide @/path/to -viewer -project \'project\' -calc GATE "', [], {
+    expect(spy).toHaveBeenCalledWith('/bin/bash -c " TICS -ide github @/path/to -viewer -project \'project\' -calc GATE "', [], {
       listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
       silent: true
     });
@@ -50,7 +50,7 @@ describe('test multiple types of configuration', () => {
 
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
-    expect(spy).toHaveBeenCalledWith(`powershell "; if ($?) {TICS -ide @/path/to -viewer -project \'project\' -calc GATE }"`, [], {
+    expect(spy).toHaveBeenCalledWith(`powershell "; if ($?) {TICS -ide github @/path/to -viewer -project \'project\' -calc GATE }"`, [], {
       listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
       silent: true
     });
@@ -72,7 +72,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "/bin/bash -c \" TICS -ide @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9\"",
+      "/bin/bash -c \" TICS -ide github @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -97,7 +97,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "powershell \"; if ($?) {TICS -ide @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9}\"",
+      "powershell \"; if ($?) {TICS -ide github @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9}\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -125,7 +125,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "/bin/bash -c \"source <(curl --silent --insecure 'http://base.com/url') && TICS -ide @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9\"",
+      "/bin/bash -c \"source <(curl --silent --insecure 'http://base.com/url') && TICS -ide github @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -153,7 +153,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;  iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/url')); if ($?) {TICS -ide @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9}\"",
+      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;  iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/url')); if ($?) {TICS -ide github @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9}\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -187,7 +187,7 @@ test('Should call exec with full TiCS command for Windows, trustStrategy set to 
   expect(response.statusCode).toEqual(0);
   expect(response.completed).toEqual(true);
   expect(spy).toHaveBeenCalledWith(
-    "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/url')); if ($?) {TICS -ide @/path/to -viewer -project 'project' -calc CS -nocalc CW -recalc CY -norecalc CD -codetype TESTCODE -cdtoken token -tmpdir '/home/ubuntu/test'  -log 9}\"",
+    "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/url')); if ($?) {TICS -ide github @/path/to -viewer -project 'project' -calc CS -nocalc CW -recalc CY -norecalc CD -codetype TESTCODE -cdtoken token -tmpdir '/home/ubuntu/test'  -log 9}\"",
     [],
     {
       listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },

--- a/test/tics/analyzer.test.ts
+++ b/test/tics/analyzer.test.ts
@@ -6,17 +6,35 @@ import { runTicsAnalyzer } from '../../src/tics/analyzer';
 
 // test for multiple different types of configurations
 describe('test multiple types of configuration', () => {
-  test('Should call exec with minimal TiCS command for Linux', async () => {
+  test('Should call exec with diagnostic TiCS command for Linux', async () => {
     const spy = jest.spyOn(exec, 'exec');
     (exec.exec as any).mockResolvedValueOnce(0);
 
     githubConfig.runnerOS = 'Linux';
+    ticsConfig.mode = 'diagnostic';
 
     const response = await runTicsAnalyzer('/path/to');
 
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
-    expect(spy).toHaveBeenCalledWith('/bin/bash -c " TICS @/path/to -viewer -project \'project\' -calc GATE "', [], {
+    expect(spy).toHaveBeenCalledWith('/bin/bash -c " TICS -ide -version "', [], {
+      listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
+      silent: true
+    });
+  });
+
+  test('Should call exec with minimal TiCS command for Linux', async () => {
+    const spy = jest.spyOn(exec, 'exec');
+    (exec.exec as any).mockResolvedValueOnce(0);
+
+    githubConfig.runnerOS = 'Linux';
+    ticsConfig.mode = 'default';
+
+    const response = await runTicsAnalyzer('/path/to');
+
+    expect(response.statusCode).toEqual(0);
+    expect(response.completed).toEqual(true);
+    expect(spy).toHaveBeenCalledWith('/bin/bash -c " TICS -ide @/path/to -viewer -project \'project\' -calc GATE "', [], {
       listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
       silent: true
     });
@@ -32,7 +50,7 @@ describe('test multiple types of configuration', () => {
 
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
-    expect(spy).toHaveBeenCalledWith(`powershell "; if ($?) {TICS @/path/to -viewer -project \'project\' -calc GATE }"`, [], {
+    expect(spy).toHaveBeenCalledWith(`powershell "; if ($?) {TICS -ide @/path/to -viewer -project \'project\' -calc GATE }"`, [], {
       listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
       silent: true
     });
@@ -54,7 +72,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "/bin/bash -c \" TICS @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9\"",
+      "/bin/bash -c \" TICS -ide @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -79,7 +97,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "powershell \"; if ($?) {TICS @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9}\"",
+      "powershell \"; if ($?) {TICS -ide @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9}\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -107,7 +125,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "/bin/bash -c \"source <(curl --silent --insecure 'http://base.com/url') && TICS @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9\"",
+      "/bin/bash -c \"source <(curl --silent --insecure 'http://base.com/url') && TICS -ide @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -135,7 +153,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;  iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/url')); if ($?) {TICS @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9}\"",
+      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;  iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/url')); if ($?) {TICS -ide @/path/to -viewer -project 'project' -calc CS -cdtoken token -tmpdir '/home/ubuntu/test' -log 9}\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -169,7 +187,7 @@ test('Should call exec with full TiCS command for Windows, trustStrategy set to 
   expect(response.statusCode).toEqual(0);
   expect(response.completed).toEqual(true);
   expect(spy).toHaveBeenCalledWith(
-    "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/url')); if ($?) {TICS @/path/to -viewer -project 'project' -calc CS -nocalc CW -recalc CY -norecalc CD -codetype TESTCODE -cdtoken token -tmpdir '/home/ubuntu/test'  -log 9}\"",
+    "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/url')); if ($?) {TICS -ide @/path/to -viewer -project 'project' -calc CS -nocalc CW -recalc CY -norecalc CD -codetype TESTCODE -cdtoken token -tmpdir '/home/ubuntu/test'  -log 9}\"",
     [],
     {
       listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },


### PR DESCRIPTION
You are now able to run the action in a diagnostic mode to test if the setup is correct.
This includes being able to run the diagnostic mode outside of a pull_request.
This is done by setting `mode: diagnostic`.