### PR TITLE
Using -help instead of -version to skip downloading artifacts

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1099,7 +1099,7 @@ async function retrieveInstallTics(os) {
 function getTicsCommand(fileListPath) {
     let execString = 'TICS -ide github ';
     if (configuration_1.ticsConfig.mode === 'diagnostic') {
-        execString += '-version ';
+        execString += '-help ';
     }
     else {
         execString += `@${fileListPath} -viewer `;
@@ -56771,13 +56771,8 @@ function resolverFromOptions(vm, options, override, compiler) {
 			}
 			const resolved = customResolver(x, path);
 			if (!resolved) return undefined;
-			if (typeof resolved === 'string') {
-				if (externals) externals.push(new RegExp('^' + escapeRegExp(resolved)));
-				return resolver.loadAsFileOrDirectory(resolved, extList);
-			}
-			const {module=x, path: resolvedPath} = resolved;
-			if (externals) externals.push(new RegExp('^' + escapeRegExp(resolvedPath)));
-			return resolver.loadNodeModules(module, [resolvedPath], extList);
+			if (externals) externals.push(new RegExp('^' + escapeRegExp(resolved)));
+			return resolver.loadAsFileOrDirecotry(resolved, extList);
 		};
 	}
 
@@ -57049,7 +57044,7 @@ class DefaultResolver extends Resolver {
 		// 2. If X begins with '/'
 		if (this.pathIsAbsolute(x)) {
 			// a. set Y to be the filesystem root
-			f = this.loadAsFileOrDirectory(x, extList);
+			f = this.loadAsFileOrDirecotry(x, extList);
 			if (f) return f;
 
 			// c. THROW "not found"
@@ -57063,13 +57058,13 @@ class DefaultResolver extends Resolver {
 					for (let i = 0; i < paths.length; i++) {
 						// a. LOAD_AS_FILE(Y + X)
 						// b. LOAD_AS_DIRECTORY(Y + X)
-						f = this.loadAsFileOrDirectory(this.pathConcat(paths[i], x), extList);
+						f = this.loadAsFileOrDirecotry(this.pathConcat(paths[i], x), extList);
 						if (f) return f;
 					}
 				} else if (paths === undefined) {
 					// a. LOAD_AS_FILE(Y + X)
 					// b. LOAD_AS_DIRECTORY(Y + X)
-					f = this.loadAsFileOrDirectory(this.pathConcat(path, x), extList);
+					f = this.loadAsFileOrDirecotry(this.pathConcat(path, x), extList);
 					if (f) return f;
 				} else {
 					throw new VMError('Invalid options.paths option.');
@@ -57077,7 +57072,7 @@ class DefaultResolver extends Resolver {
 			} else {
 				// a. LOAD_AS_FILE(Y + X)
 				// b. LOAD_AS_DIRECTORY(Y + X)
-				f = this.loadAsFileOrDirectory(this.pathConcat(path, x), extList);
+				f = this.loadAsFileOrDirecotry(this.pathConcat(path, x), extList);
 				if (f) return f;
 			}
 
@@ -57122,7 +57117,7 @@ class DefaultResolver extends Resolver {
 		return super.resolveFull(mod, x, options, ext, direct);
 	}
 
-	loadAsFileOrDirectory(x, extList) {
+	loadAsFileOrDirecotry(x, extList) {
 		// a. LOAD_AS_FILE(X)
 		const f = this.loadAsFile(x, extList);
 		if (f) return f;
@@ -57362,7 +57357,7 @@ class DefaultResolver extends Resolver {
 		} else {
 			// a. LOAD_AS_FILE(RESOLVED_PATH)
 			// b. LOAD_AS_DIRECTORY(RESOLVED_PATH)
-			f = this.loadAsFileOrDirectory(resolvedPath, extList);
+			f = this.loadAsFileOrDirecotry(resolvedPath, extList);
 		}
 		if (f) return f;
 		// 5. THROW "not found"

--- a/dist/setup-sandbox.js
+++ b/dist/setup-sandbox.js
@@ -276,30 +276,13 @@ if (typeof OriginalCallSite === 'function') {
 				return;
 			}
 			const newWrapped = (error, sst) => {
-				const sandboxSst = ensureThis(sst);
 				if (localArrayIsArray(sst)) {
-					if (sst === sandboxSst) {
-						for (let i=0; i < sst.length; i++) {
-							const cs = sst[i];
-							if (typeof cs === 'object' && localReflectGetPrototypeOf(cs) === OriginalCallSite.prototype) {
-								sst[i] = new CallSite(cs);
-							}
-						}
-					} else {
-						sst = [];
-						for (let i=0; i < sandboxSst.length; i++) {
-							const cs = sandboxSst[i];
-							localReflectDefineProperty(sst, i, {
-								__proto__: null,
-								value: new CallSite(cs),
-								enumerable: true,
-								configurable: true,
-								writable: true
-							});
+					for (let i=0; i < sst.length; i++) {
+						const cs = sst[i];
+						if (typeof cs === 'object' && localReflectGetPrototypeOf(cs) === OriginalCallSite.prototype) {
+							sst[i] = new CallSite(cs);
 						}
 					}
-				} else {
-					sst = sandboxSst;
 				}
 				return value(error, sst);
 			};

--- a/src/tics/analyzer.ts
+++ b/src/tics/analyzer.ts
@@ -132,7 +132,7 @@ async function retrieveInstallTics(os: string) {
 function getTicsCommand(fileListPath: string) {
   let execString = 'TICS -ide github ';
   if (ticsConfig.mode === 'diagnostic') {
-    execString += '-version ';
+    execString += '-help ';
   } else {
     execString += `@${fileListPath} -viewer `;
     execString += `-project '${ticsConfig.projectName}' `;

--- a/test/tics/analyzer.test.ts
+++ b/test/tics/analyzer.test.ts
@@ -17,7 +17,7 @@ describe('test multiple types of configuration', () => {
 
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
-    expect(spy).toHaveBeenCalledWith('/bin/bash -c " TICS -ide github -version "', [], {
+    expect(spy).toHaveBeenCalledWith('/bin/bash -c " TICS -ide github -help "', [], {
       listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
       silent: true
     });


### PR DESCRIPTION
The diagnostic mode tests the health of the infrastructure TICS is running in.
However, there was a >2GB file failing to download. This is blocking the pipeline.

The download of this >2GB file is considered undesired. Therefore we should switch from executing
TICS -version to TICS -help.

This will result in having only TICS itself downloaded.
