### PR TITLE
Fixed `could not retrieve the changed files` on large pull requests

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -957,19 +957,37 @@ function createReviewComments(annotations, changedFiles) {
     let postable = [];
     groupedAnnotations.forEach(annotation => {
         const displayCount = annotation.count === 1 ? '' : `(${annotation.count}x) `;
-        if (annotation.diffLines?.includes(annotation.line)) {
-            logger_1.logger.debug(`Postable: ${JSON.stringify(annotation)}`);
-            postable.push({
-                title: `${annotation.instanceName}: ${annotation.rule}`,
-                body: createBody(annotation, displayCount),
-                path: annotation.path,
-                line: annotation.line
-            });
+        if (configuration_1.githubConfig.eventName === 'pull_request') {
+            if (changedFiles.find(c => annotation.fullPath.includes(c.filename))) {
+                logger_1.logger.debug(`Postable: ${JSON.stringify(annotation)}`);
+                postable.push({
+                    title: `${annotation.instanceName}: ${annotation.rule}`,
+                    body: createBody(annotation, displayCount),
+                    path: annotation.path,
+                    line: annotation.line
+                });
+            }
+            else {
+                annotation.displayCount = displayCount;
+                logger_1.logger.debug(`Unpostable: ${JSON.stringify(annotation)}`);
+                unpostable.push(annotation);
+            }
         }
         else {
-            annotation.displayCount = displayCount;
-            logger_1.logger.debug(`Unpostable: ${JSON.stringify(annotation)}`);
-            unpostable.push(annotation);
+            if (annotation.diffLines?.includes(annotation.line)) {
+                logger_1.logger.debug(`Postable: ${JSON.stringify(annotation)}`);
+                postable.push({
+                    title: `${annotation.instanceName}: ${annotation.rule}`,
+                    body: createBody(annotation, displayCount),
+                    path: annotation.path,
+                    line: annotation.line
+                });
+            }
+            else {
+                annotation.displayCount = displayCount;
+                logger_1.logger.debug(`Unpostable: ${JSON.stringify(annotation)}`);
+                unpostable.push(annotation);
+            }
         }
     });
     logger_1.logger.info('Created review comments from annotations.');

--- a/dist/index.js
+++ b/dist/index.js
@@ -458,6 +458,7 @@ async function getChangedFilesOfPullRequest() {
     };
     let files = [];
     try {
+        logger_1.logger.header('Retrieving changed files.');
         let response;
         do {
             response = await configuration_1.octokit.graphql(`query($owner: String!, $repo: String!, $pull_number: Int!, $per_page: Int!, $after: String) {

--- a/src/github/commits.ts
+++ b/src/github/commits.ts
@@ -24,7 +24,7 @@ export async function getChangedFilesOfCommit(): Promise<ChangedFile[]> {
             // If a file is moved or renamed the status is 'renamed'.
             if (item.status === 'renamed') {
               // If a files has been moved without changes or if moved files are excluded, exclude them.
-              if (ticsConfig.excludeMovedFiles || item.changes === 0) {
+              if ((ticsConfig.excludeMovedFiles && item.changes === 0) || item.changes === 0) {
                 return false;
               }
             }

--- a/src/github/interfaces.d.ts
+++ b/src/github/interfaces.d.ts
@@ -122,15 +122,53 @@ export interface Comment {
 }
 
 export interface ChangedFile {
-  sha: string;
   filename: string;
-  status: 'added' | 'removed' | 'modified' | 'renamed' | 'copied' | 'changed' | 'unchanged';
+  status: 'added' | 'changed' | 'copied' | 'removed' | 'modified' | 'renamed' | 'unchanged';
   additions: number;
   deletions: number;
   changes: number;
-  blob_url: string;
-  raw_url: string;
-  contents_url: string;
+  sha?: string;
+  blob_url?: string;
+  raw_url?: string;
+  contents_url?: string;
   patch?: string | undefined;
   previous_filename?: string | undefined;
+}
+
+export type GraphQlParams = {
+  owner: string;
+  repo: string;
+  pull_number: number;
+  per_page: number;
+  after?: string;
+};
+
+export interface GraphQlChangedFile {
+  path: string;
+  changeType: 'ADDED' | 'CHANGED' | 'COPIED' | 'DELETED' | 'MODIFIED' | 'RENAMED';
+  additions: number;
+  deletions: number;
+}
+
+export interface GraphQlResponse<T> {
+  repository: {
+    pullRequest: T;
+  };
+}
+
+export interface ChangedFileResData {
+  files: {
+    totalCount: number;
+    pageInfo: {
+      endCursor: string;
+      hasNextPage: boolean;
+    };
+    nodes: GraphQlChangedFile[];
+  };
+}
+
+export interface HeadRepositoryOwnerResData {
+  headRepositoryOwner: {
+    login: string;
+  };
 }

--- a/src/github/pulls.ts
+++ b/src/github/pulls.ts
@@ -2,48 +2,82 @@ import { writeFileSync } from 'fs';
 import { normalize, resolve } from 'canonical-path';
 import { logger } from '../helper/logger';
 import { githubConfig, octokit, ticsConfig } from '../configuration';
-import { ChangedFile } from './interfaces';
+import { ChangedFile, ChangedFileResData, GraphQlResponse, GraphQlChangedFile, GraphQlParams } from './interfaces';
 import { handleOctokitError as getMessageFromOctokitError } from '../helper/error';
+import { ChangeType } from '../helper/enums';
 
 /**
  * Sends a request to retrieve the changed files for a given pull request to the GitHub API.
  * @returns List of changed files within the GitHub Pull request.
  */
 export async function getChangedFilesOfPullRequest(): Promise<ChangedFile[]> {
-  const params = {
+  const params: GraphQlParams = {
     owner: githubConfig.owner,
     repo: githubConfig.reponame,
-    pull_number: githubConfig.pullRequestNumber
+    pull_number: githubConfig.pullRequestNumber,
+    per_page: 100,
+    after: undefined
   };
-  let response: ChangedFile[] = [];
+  let files: ChangedFile[] = [];
   try {
-    logger.header('Retrieving changed files.');
-    response = await octokit.paginate(octokit.rest.pulls.listFiles, params, response => {
-      let files = response.data
-        .filter(item => {
-          if (item.status === 'renamed') {
-            // If a files has been moved without changes or if moved files are excluded, exclude them.
-            if (ticsConfig.excludeMovedFiles || item.changes === 0) {
-              return false;
+    let response: GraphQlResponse<ChangedFileResData>;
+    do {
+      response = await octokit.graphql<GraphQlResponse<ChangedFileResData>>(
+        `query($owner: String!, $repo: String!, $pull_number: Int!, $per_page: Int!, $after: String) {
+          rateLimit {
+            remaining
+          }
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $pull_number) {
+              files(first: $per_page, after: $after) {
+                totalCount
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
+                nodes {
+                  path
+                  changeType
+                  additions
+                  deletions
+                }
+              }
             }
           }
-          return true;
-        })
-        .map(item => {
-          // If a file is moved or renamed the status is 'renamed'.
-          item.filename = normalize(item.filename);
-          logger.debug(item.filename);
-          return item;
-        });
-
-      return files ? files : [];
-    });
+        }`,
+        params
+      );
+      files = files.concat(
+        response.repository.pullRequest.files.nodes
+          .map((item: GraphQlChangedFile) => {
+            const changedFile: ChangedFile = {
+              filename: normalize(item.path),
+              additions: item.additions,
+              deletions: item.deletions,
+              changes: item.additions + item.deletions,
+              status: ChangeType[item.changeType]
+            };
+            return changedFile;
+          })
+          .filter((item: ChangedFile) => {
+            if (item.status === 'renamed') {
+              // If a files has been moved without changes or if moved files are excluded, exclude them.
+              if ((ticsConfig.excludeMovedFiles && item.changes === 0) || item.changes === 0) {
+                return false;
+              }
+            }
+            logger.debug(item.filename);
+            return true;
+          })
+      );
+      params.after = response.repository.pullRequest.files.pageInfo.endCursor;
+    } while (response.repository.pullRequest.files.pageInfo.hasNextPage);
     logger.info('Retrieved changed files from pull request.');
   } catch (error: unknown) {
     const message = getMessageFromOctokitError(error);
     throw Error(`Could not retrieve the changed files: ${message}`);
   }
-  return response;
+  return files;
 }
 
 /**

--- a/src/github/pulls.ts
+++ b/src/github/pulls.ts
@@ -20,6 +20,7 @@ export async function getChangedFilesOfPullRequest(): Promise<ChangedFile[]> {
   };
   let files: ChangedFile[] = [];
   try {
+    logger.header('Retrieving changed files.');
     let response: GraphQlResponse<ChangedFileResData>;
     do {
       response = await octokit.graphql<GraphQlResponse<ChangedFileResData>>(

--- a/src/helper/enums.ts
+++ b/src/helper/enums.ts
@@ -10,3 +10,12 @@ export enum Events {
   'COMMENT' = 'COMMENT',
   'REQUEST_CHANGES' = 'REQUEST_CHANGES'
 }
+
+export enum ChangeType {
+  ADDED = 'added',
+  CHANGED = 'changed',
+  COPIED = 'copied',
+  DELETED = 'removed',
+  MODIFIED = 'modified',
+  RENAMED = 'renamed'
+}

--- a/test/.setup/mock.ts
+++ b/test/.setup/mock.ts
@@ -44,7 +44,8 @@ jest.mock('../../src/configuration', () => {
         repos: {
           getCommit: jest.fn()
         }
-      }
+      },
+      graphql: jest.fn()
     },
     httpClient: {
       get: jest.fn()

--- a/test/integration/octokit.test.ts
+++ b/test/integration/octokit.test.ts
@@ -21,6 +21,7 @@ process.env.INPUT_PULLREQUESTAPPROVAL = 'false';
 // eslint-disable-next-line import/first
 import { octokit } from '../../src/configuration';
 import { RequestError } from '@octokit/request-error';
+import { GraphQlResponse, HeadRepositoryOwnerResData } from '../../src/github/interfaces';
 
 describe('@octokit/action (using https_proxy)', () => {
   let proxyServer: http.Server;
@@ -54,6 +55,28 @@ describe('@octokit/action (using https_proxy)', () => {
     if (originalhttpProxyUrl) {
       process.env['http_proxy'] = originalhttpProxyUrl;
     }
+  });
+
+  test('Should return basic graphql request through the proxy', async () => {
+    const response = await octokit.graphql<GraphQlResponse<HeadRepositoryOwnerResData>>(
+      `query($owner: String!, $repo: String!, $pull_number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $pull_number) {
+            headRepositoryOwner {
+              login
+            }
+          }
+        }
+      }`,
+      {
+        owner: 'tiobe',
+        repo: 'tics-github-action',
+        pull_number: 1
+      }
+    );
+
+    expect(response.repository.pullRequest.headRepositoryOwner.login).toEqual('tiobe');
+    expect(proxyConnects.length).toEqual(1);
   });
 
   test('Should return basic REST request, but not through the proxy', async () => {

--- a/test/unit/github/commits.test.ts
+++ b/test/unit/github/commits.test.ts
@@ -57,7 +57,7 @@ describe('getChangedFilesOfCommit', () => {
     (octokit.paginate as any).mock.calls[0][2]({
       data: { files: [{ filename: 'test.js', status: 'renamed', changes: 1 }, { filename: 'test.js' }] }
     });
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledTimes(2);
     expect(spy).toHaveBeenCalledWith('test.js');
   });
 

--- a/test/unit/github/objects/pulls.ts
+++ b/test/unit/github/objects/pulls.ts
@@ -1,4 +1,122 @@
-import { ChangedFile } from '../../../../src/github/interfaces';
+import { ChangedFile, ChangedFileResData, GraphQlResponse } from '../../../../src/github/interfaces';
+
+export const singleFileResponse: GraphQlResponse<ChangedFileResData> = {
+  repository: {
+    pullRequest: {
+      files: {
+        totalCount: 22,
+        pageInfo: {
+          endCursor: 'MjI',
+          hasNextPage: false
+        },
+        nodes: [
+          {
+            path: 'test.js',
+            changeType: 'MODIFIED',
+            additions: 3,
+            deletions: 1
+          }
+        ]
+      }
+    }
+  }
+};
+
+export const renamedChangedFileResponse: GraphQlResponse<ChangedFileResData> = {
+  repository: {
+    pullRequest: {
+      files: {
+        totalCount: 22,
+        pageInfo: {
+          endCursor: 'MjI',
+          hasNextPage: false
+        },
+        nodes: [
+          {
+            path: 'test.js',
+            changeType: 'MODIFIED',
+            additions: 3,
+            deletions: 1
+          },
+          {
+            path: 'jest.js',
+            changeType: 'RENAMED',
+            additions: 3,
+            deletions: 1
+          }
+        ]
+      }
+    }
+  }
+};
+
+export const renamedUnchangedFileResponse: GraphQlResponse<ChangedFileResData> = {
+  repository: {
+    pullRequest: {
+      files: {
+        totalCount: 22,
+        pageInfo: {
+          endCursor: 'MjI',
+          hasNextPage: false
+        },
+        nodes: [
+          {
+            path: 'test.js',
+            changeType: 'MODIFIED',
+            additions: 3,
+            deletions: 1
+          },
+          {
+            path: 'jest.js',
+            changeType: 'RENAMED',
+            additions: 0,
+            deletions: 0
+          }
+        ]
+      }
+    }
+  }
+};
+
+export const fourFilesChangedResponse: GraphQlResponse<ChangedFileResData> = {
+  repository: {
+    pullRequest: {
+      files: {
+        totalCount: 22,
+        pageInfo: {
+          endCursor: 'MjI',
+          hasNextPage: false
+        },
+        nodes: [
+          {
+            path: 'test.js',
+            changeType: 'ADDED',
+            additions: 3,
+            deletions: 0
+          },
+          {
+            path: 'jest.js',
+            changeType: 'CHANGED',
+            additions: 3,
+            deletions: 1
+          },
+          {
+            path: 'gest.js',
+            changeType: 'DELETED',
+            additions: 0,
+            deletions: 5
+          },
+          {
+            path: 'vest.js',
+            changeType: 'COPIED',
+            additions: 10,
+            deletions: 5
+          }
+        ]
+      }
+    }
+  }
+};
 
 export const changedFile: ChangedFile = {
   sha: '',

--- a/test/unit/github/pulls.test.ts
+++ b/test/unit/github/pulls.test.ts
@@ -3,67 +3,102 @@ import { resolve } from 'canonical-path';
 import { changedFilesToFile, getChangedFilesOfPullRequest } from '../../../src/github/pulls';
 import { octokit, ticsConfig } from '../../../src/configuration';
 import { logger } from '../../../src/helper/logger';
-import { changedFile } from './objects/pulls';
+import { changedFile, fourFilesChangedResponse, renamedChangedFileResponse, renamedUnchangedFileResponse, singleFileResponse } from './objects/pulls';
 
 describe('getChangedFilesOfPullRequest', () => {
   test('Should return single file on getChangedFilesOfPullRequest', async () => {
-    (octokit.paginate as any).mockReturnValueOnce([{ filename: 'test.js' }]);
+    (octokit.graphql as any).mockReturnValueOnce(singleFileResponse);
+    const spy = jest.spyOn(logger, 'debug');
 
     const response = await getChangedFilesOfPullRequest();
-    expect(response).toEqual([{ filename: 'test.js' }]);
+    expect(response).toEqual([
+      {
+        additions: 3,
+        changes: 4,
+        deletions: 1,
+        filename: 'test.js',
+        status: 'modified'
+      }
+    ]);
+    expect(spy).toBeCalledTimes(1);
   });
 
   test('Should include changed moved file', async () => {
+    (octokit.graphql as any).mockReturnValueOnce(renamedChangedFileResponse);
     const spy = jest.spyOn(logger, 'debug');
-    await getChangedFilesOfPullRequest();
 
-    (octokit.paginate as any).mock.calls[0][2]({ data: [{ filename: 'test.js', status: 'renamed', changes: 1 }, { filename: 'test.js' }] });
-    expect(spy).toHaveBeenCalledTimes(2);
-    expect(spy).toHaveBeenCalledWith('test.js');
+    const response = await getChangedFilesOfPullRequest();
+    expect(response).toEqual([
+      {
+        additions: 3,
+        changes: 4,
+        deletions: 1,
+        filename: 'test.js',
+        status: 'modified'
+      },
+      {
+        additions: 3,
+        changes: 4,
+        deletions: 1,
+        filename: 'jest.js',
+        status: 'renamed'
+      }
+    ]);
+    expect(spy).toBeCalledTimes(2);
   });
 
   test('Should exclude unchanged moved file', async () => {
+    (octokit.graphql as any).mockReturnValueOnce(renamedUnchangedFileResponse);
     const spy = jest.spyOn(logger, 'debug');
-    await getChangedFilesOfPullRequest();
 
-    (octokit.paginate as any).mock.calls[0][2]({ data: [{ filename: 'test.js', status: 'renamed', changes: 0 }, { filename: 'test.js' }] });
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith('test.js');
+    const response = await getChangedFilesOfPullRequest();
+    expect(response).toEqual([
+      {
+        additions: 3,
+        changes: 4,
+        deletions: 1,
+        filename: 'test.js',
+        status: 'modified'
+      }
+    ]);
+    expect(spy).toBeCalledTimes(1);
   });
 
   test('Should include changed moved file on excludeMovedFiles', async () => {
     ticsConfig.excludeMovedFiles = true;
 
     const spy = jest.spyOn(logger, 'debug');
-    await getChangedFilesOfPullRequest();
-
-    (octokit.paginate as any).mock.calls[0][2]({ data: [{ filename: 'test.js', status: 'renamed', changes: 1 }, { filename: 'test.js' }] });
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith('test.js');
-  });
-
-  test('Should call debug on callback of paginate', async () => {
-    const spy = jest.spyOn(logger, 'debug');
-    await getChangedFilesOfPullRequest();
-
-    (octokit.paginate as any).mock.calls[0][2]({ data: [{ filename: 'test.js' }, { filename: 'test.js' }] });
-    expect(spy).toHaveBeenCalledTimes(2);
-    expect(spy).toHaveBeenCalledWith('test.js');
-  });
-
-  test('Should be called with specific parameters on getChangedFilesOfPullRequest', async () => {
-    (octokit.paginate as any).mockReturnValueOnce();
-    const spy = jest.spyOn(octokit, 'paginate');
-
-    await getChangedFilesOfPullRequest();
-    expect(spy).toHaveBeenCalledWith(octokit.rest.pulls.listFiles, { repo: 'test', owner: 'tester', pull_number: '1' }, expect.any(Function));
-  });
-
-  test('Should return three files on getChangedFilesOfPullRequest', async () => {
-    (octokit.paginate as any).mockReturnValueOnce([{}, {}, {}]);
+    (octokit.graphql as any).mockReturnValueOnce(renamedChangedFileResponse);
 
     const response = await getChangedFilesOfPullRequest();
-    expect((response as any[]).length).toEqual(3);
+    expect(response).toEqual([
+      {
+        additions: 3,
+        changes: 4,
+        deletions: 1,
+        filename: 'test.js',
+        status: 'modified'
+      },
+      {
+        additions: 3,
+        changes: 4,
+        deletions: 1,
+        filename: 'jest.js',
+        status: 'renamed'
+      }
+    ]);
+    expect(spy).toBeCalledTimes(2);
+  });
+
+  test('Should return four files on getChangedFilesOfPullRequest', async () => {
+    ticsConfig.excludeMovedFiles = true;
+
+    const spy = jest.spyOn(logger, 'debug');
+    (octokit.graphql as any).mockReturnValueOnce(fourFilesChangedResponse);
+
+    const response = await getChangedFilesOfPullRequest();
+    expect(response.length).toEqual(4);
+    expect(spy).toBeCalledTimes(4);
   });
 
   test('Should call exit on thrown error on paginate', async () => {

--- a/test/unit/helper/summary.test.ts
+++ b/test/unit/helper/summary.test.ts
@@ -106,18 +106,14 @@ describe('createReviewComments', () => {
   });
 
   test('Should return one combined postable review comment for the same line', async () => {
+    githubConfig.eventName = 'pull_request';
     const changedFiles: ChangedFile[] = [
       {
-        sha: 'sha',
         filename: 'src/test.js',
         status: 'modified',
         additions: 1,
         deletions: 1,
-        changes: 2,
-        blob_url: 'url',
-        raw_url: 'url',
-        contents_url: 'url',
-        patch: '@@ -0,1 +0,1 @@'
+        changes: 2
       }
     ];
     const annotations = [
@@ -163,16 +159,11 @@ describe('createReviewComments', () => {
   test('Should return one postable and one unpostable review comment', async () => {
     const changedFiles: ChangedFile[] = [
       {
-        sha: 'sha',
         filename: 'src/test.js',
         status: 'modified',
         additions: 1,
         deletions: 1,
-        changes: 2,
-        blob_url: 'url',
-        raw_url: 'url',
-        contents_url: 'url',
-        patch: '@@ -0,1 +0,1 @@'
+        changes: 2
       }
     ];
     const annotations = [
@@ -259,6 +250,103 @@ describe('createReviewComments', () => {
     const response = createReviewComments(annotations, changedFiles);
     expect(response).toEqual({ postable: expected_postable, unpostable: expected_unpostable });
   });
+});
+
+test('Should return one postable and one unpostable review comment', async () => {
+  githubConfig.eventName = 'push';
+  const changedFiles: ChangedFile[] = [
+    {
+      filename: 'src/test.js',
+      status: 'modified',
+      additions: 1,
+      deletions: 1,
+      changes: 2,
+      patch: '@@ -0,1 +0,1 @@'
+    }
+  ];
+  const annotations = [
+    {
+      fullPath: 'c:/src/test.js',
+      line: 0,
+      level: 1,
+      category: 'test',
+      type: 'test',
+      rule: 'test',
+      msg: 'test',
+      count: 1,
+      supp: false,
+      instanceName: 'test'
+    },
+    {
+      fullPath: 'HIE://project/branch/src/jest.js',
+      line: 2,
+      level: 1,
+      category: 'test',
+      type: 'test',
+      rule: 'test',
+      msg: 'test',
+      count: 1,
+      supp: false,
+      instanceName: 'test'
+    },
+    {
+      fullPath: 'HIE://project/branch/src/zest.js',
+      line: 2,
+      level: 1,
+      category: 'test',
+      type: 'test',
+      rule: 'test',
+      msg: 'test',
+      count: 1,
+      supp: false,
+      instanceName: 'test'
+    }
+  ];
+
+  const expected_postable = [
+    {
+      title: 'test: test',
+      path: 'src/test.js',
+      line: 0,
+      body: 'Line: 0: test\r\nLevel: 1, Category: test'
+    }
+  ];
+
+  const expected_unpostable = [
+    {
+      path: 'src/jest.js',
+      fullPath: 'HIE://project/branch/src/jest.js',
+      line: 2,
+      level: 1,
+      category: 'test',
+      type: 'test',
+      rule: 'test',
+      msg: 'test',
+      count: 1,
+      supp: false,
+      displayCount: '',
+      diffLines: [],
+      instanceName: 'test'
+    },
+    {
+      path: 'src/zest.js',
+      fullPath: 'HIE://project/branch/src/zest.js',
+      line: 2,
+      level: 1,
+      category: 'test',
+      type: 'test',
+      rule: 'test',
+      msg: 'test',
+      count: 1,
+      supp: false,
+      displayCount: '',
+      diffLines: [],
+      instanceName: 'test'
+    }
+  ];
+
+  const response = createReviewComments(annotations, changedFiles);
+  expect(response).toEqual({ postable: expected_postable, unpostable: expected_unpostable });
 });
 
 describe('createUnpostableReviewCommentsSummary', () => {

--- a/test/unit/main.test.ts
+++ b/test/unit/main.test.ts
@@ -375,7 +375,6 @@ describe('Diagnostic mode checks', () => {
     ticsConfig.mode = 'diagnostic';
     const spySetFailed = jest.spyOn(logger, 'setFailed');
 
-    console.log('test');
     await main.main();
 
     expect(spyAnalyzer).toHaveBeenCalledTimes(1);

--- a/test/unit/main_helper.ts
+++ b/test/unit/main_helper.ts
@@ -1,61 +1,30 @@
+import { ChangedFile } from '../../src/github/interfaces';
 import { AnalysisResults, ExtendedAnnotation, QualityGate } from '../../src/helper/interfaces';
 
-interface changedFile {
-  sha: string;
-  filename: string;
-  status: 'modified' | 'added' | 'removed' | 'renamed' | 'copied' | 'changed' | 'unchanged';
-  additions: number;
-  deletions: number;
-  changes: number;
-  blob_url: string;
-  raw_url: string;
-  contents_url: string;
-  patch?: string | undefined;
-  previous_filename?: string | undefined;
-}
-
-export const singleChangedFiles: changedFile[] = [
+export const singleChangedFiles: ChangedFile[] = [
   {
-    sha: 'test',
     filename: 'test.js',
     status: 'modified',
     additions: 1,
     deletions: 1,
-    changes: 1,
-    blob_url: 'url',
-    raw_url: 'url',
-    contents_url: 'url',
-    patch: '@@ -0,1 +0,1 @@',
-    previous_filename: undefined
+    changes: 1
   }
 ];
 
-export const doubleChangedFiles: changedFile[] = [
+export const doubleChangedFiles: ChangedFile[] = [
   {
-    sha: 'test',
     filename: 'test.js',
     status: 'modified',
     additions: 1,
     deletions: 1,
-    changes: 1,
-    blob_url: 'url',
-    raw_url: 'url',
-    contents_url: 'url',
-    patch: '@@ -0,1 +0,1 @@',
-    previous_filename: undefined
+    changes: 1
   },
   {
-    sha: 'jest',
     filename: 'jest.js',
     status: 'modified',
     additions: 1,
     deletions: 1,
-    changes: 1,
-    blob_url: 'url',
-    raw_url: 'url',
-    contents_url: 'url',
-    patch: '@@ -0,1 +0,1 @@',
-    previous_filename: undefined
+    changes: 1
   }
 ];
 
@@ -296,17 +265,6 @@ export const singlePreviousReviewComments = [
     id: 1
   }
 ];
-
-export const singleExpectedPostable = {
-  postable: [
-    {
-      path: 'test.js',
-      line: 0,
-      body: ':warning: **TICS: test violation: test**\r\nLine: 0, Rule: test, Level: 1, Category: test\r\n'
-    }
-  ],
-  unpostable: []
-};
 
 export const analysisResultsPassedNoUrl: AnalysisResults = {
   passed: false,


### PR DESCRIPTION
Rewrote retrieving changed files of a pull request using GraphQL. It replaces the previous implementation, which retrieved the diff which took too long to calculate on files that are too large.
https://docs.github.com/en/repositories/creating-and-managing-repositories/repository-limits#diff-limits

Changed the tests and interfaces accordingly. Also fixed bug in commits.ts, it excluded renamed files on excludeMovedFiles even if changes were made to it.