### PR TITLE
Cope with official TICS release numbers 'r2024.1.0'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@octokit/request-error": "^5.0.1",
         "@tiobe/http-client": "^0.4.0",
         "@tiobe/install-tics": "^0.5.0",
+        "@types/semver": "^7.5.8",
         "canonical-path": "^1.0.0",
         "compare-versions": "^6.1.0",
         "date-fns": "^3.3.1",
@@ -1849,6 +1850,11 @@
         "@types/node": "*",
         "form-data": "^4.0.0"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ=="
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@octokit/request-error": "^5.0.1",
     "@tiobe/http-client": "^0.4.0",
     "@tiobe/install-tics": "^0.5.0",
+    "@types/semver": "^7.5.8",
     "canonical-path": "^1.0.0",
     "compare-versions": "^6.1.0",
     "date-fns": "^3.3.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -237,7 +237,7 @@ export function configure(): void {
  */
 async function meetsPrerequisites(): Promise<void> {
   const viewerVersion = await getViewerVersion();
-  const cleanViewerVersion = viewerVersion ? coerce(viewerVersion.version, { loose: true }) : null;
+  const cleanViewerVersion = viewerVersion ? coerce(viewerVersion.version) : null;
   if (!cleanViewerVersion || !satisfies(cleanViewerVersion, '>=2022.4.0')) {
     const version = cleanViewerVersion ?? 'unknown';
     throw Error(`Minimum required TICS Viewer version is 2022.4. Found version ${version}.`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,12 +10,12 @@ import { postNothingAnalyzedReview, postReview } from './github/review';
 import { createSummaryBody } from './helper/summary';
 import { getPostedReviewComments, postAnnotations, deletePreviousReviewComments } from './github/annotations';
 import { Events } from './helper/enums';
-import { satisfies } from 'compare-versions';
 import { exportVariable, summary } from '@actions/core';
 import { Analysis } from './helper/interfaces';
 import { uploadArtifact } from './github/artifacts';
 import { getChangedFilesOfCommit } from './github/commits';
 import { ChangedFiles } from './interfaces';
+import { coerce, satisfies } from 'semver';
 
 // export for testing purposes
 export let actionFailed: string | undefined;
@@ -237,9 +237,9 @@ export function configure(): void {
  */
 async function meetsPrerequisites(): Promise<void> {
   const viewerVersion = await getViewerVersion();
-
-  if (!viewerVersion || !satisfies(viewerVersion.version, '>=2022.4.0')) {
-    const version = viewerVersion ? viewerVersion.version : 'unknown';
+  const cleanViewerVersion = viewerVersion ? coerce(viewerVersion.version, { loose: true }) : null;
+  if (!cleanViewerVersion || !satisfies(cleanViewerVersion, '>=2022.4.0')) {
+    const version = cleanViewerVersion ?? 'unknown';
     throw Error(`Minimum required TICS Viewer version is 2022.4. Found version ${version}.`);
   } else if (ticsConfig.mode === 'diagnostic') {
     // No need for checked out repository.

--- a/src/main.ts
+++ b/src/main.ts
@@ -239,7 +239,7 @@ async function meetsPrerequisites(): Promise<void> {
   const viewerVersion = await getViewerVersion();
   const cleanViewerVersion = viewerVersion ? coerce(viewerVersion.version) : null;
   if (!cleanViewerVersion || !satisfies(cleanViewerVersion, '>=2022.4.0')) {
-    const version = cleanViewerVersion ?? 'unknown';
+    const version = cleanViewerVersion?.toString() ?? 'unknown';
     throw Error(`Minimum required TICS Viewer version is 2022.4. Found version ${version}.`);
   } else if (ticsConfig.mode === 'diagnostic') {
     // No need for checked out repository.

--- a/test/unit/main.test.ts
+++ b/test/unit/main.test.ts
@@ -48,6 +48,35 @@ describe('pre checks', () => {
     expect((error as Error).message).toEqual(expect.stringContaining('Minimum required TICS Viewer version is 2022.4. Found version 2022.0.0.'));
   });
 
+  test('Should throw error if viewer version is too low with prefix character', async () => {
+    jest.spyOn(fetcher, 'getViewerVersion').mockResolvedValue({ version: 'r2022.0.0' });
+
+    let error: any;
+    try {
+      await main.main();
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toEqual(expect.stringContaining('Minimum required TICS Viewer version is 2022.4. Found version 2022.0.0.'));
+  });
+
+  test('Should not throw version error if viewer version sufficient with prefix character', async () => {
+    jest.spyOn(fetcher, 'getViewerVersion').mockResolvedValue({ version: 'r2022.4.0' });
+
+    let error: any;
+    try {
+      await main.main();
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toEqual(
+      expect.stringContaining('If the the action is run outside a pull request it should be run with a filelist.')
+    );
+  });
+
   test('Should throw error if event is not pull request and', async () => {
     jest.spyOn(fetcher, 'getViewerVersion').mockResolvedValue({ version: '2022.4.0' });
     jest.spyOn(main, 'configure').mockImplementation();


### PR DESCRIPTION
Fixes [PR33775](https://redmine.tiobe.com/issues/33775). 

We now loosely parse the viewer version number, rather than strictly.