### PR TITLE
All non-failing errors are now displayed as notices

### DIFF
--- a/src/github/annotations.ts
+++ b/src/github/annotations.ts
@@ -20,7 +20,7 @@ export async function getPostedReviewComments(): Promise<ReviewComment[]> {
     response = await octokit.paginate(octokit.rest.pulls.listReviewComments, params);
   } catch (error: unknown) {
     const message = handleOctokitError(error);
-    logger.error(`Could not retrieve the review comments: ${message}`);
+    logger.notice(`Could not retrieve the review comments: ${message}`);
   }
   logger.info('Retrieve posted review comments.');
   return response;
@@ -76,7 +76,7 @@ export function deletePreviousReviewComments(postedReviewComments: ReviewComment
         await octokit.rest.pulls.deleteReviewComment(params);
       } catch (error: unknown) {
         const message = handleOctokitError(error);
-        logger.error(`Could not delete review comment: ${message}`);
+        logger.notice(`Could not delete review comment: ${message}`);
       }
     }
   });

--- a/src/github/comments.ts
+++ b/src/github/comments.ts
@@ -21,11 +21,11 @@ export async function getPostedComments(): Promise<Comment[]> {
       issue_number: githubConfig.pullRequestNumber
     };
     response = await octokit.paginate(octokit.rest.issues.listComments, params);
+    logger.info('Retrieved posted comments.');
   } catch (error: unknown) {
     const message = handleOctokitError(error);
-    logger.error(`Could not retrieve the comments: ${message}`);
+    logger.notice(`Could not retrieve the comments: ${message}`);
   }
-  logger.info('Retrieved posted comments.');
   return response;
 }
 
@@ -67,13 +67,13 @@ export async function postComment(body: string): Promise<void> {
     logger.info('Posted comment for this pull request.');
   } catch (error: unknown) {
     const message = handleOctokitError(error);
-    logger.error(`Posting the comment failed: ${message}`);
+    logger.notice(`Posting the comment failed: ${message}`);
   }
 }
 
-export function deletePreviousComments(comments: Comment[]): void {
+export async function deletePreviousComments(comments: Comment[]): Promise<void> {
   logger.header('Deleting comments of previous runs.');
-  comments.map(async comment => {
+  for (const comment of comments) {
     if (commentIncludesTicsTitle(comment.body)) {
       try {
         const params = {
@@ -84,10 +84,10 @@ export function deletePreviousComments(comments: Comment[]): void {
         await octokit.rest.issues.deleteComment(params);
       } catch (error: unknown) {
         const message = handleOctokitError(error);
-        logger.error(`Removing a comment failed: ${message}`);
+        logger.notice(`Removing a comment failed: ${message}`);
       }
     }
-  });
+  }
   logger.info('Deleted review comments of previous runs.');
 }
 

--- a/src/github/review.ts
+++ b/src/github/review.ts
@@ -24,7 +24,7 @@ export async function postReview(body: string, event: Events): Promise<void> {
     logger.info('Posted review for this pull request.');
   } catch (error: unknown) {
     const message = handleOctokitError(error);
-    logger.error(`Posting the review failed: ${message}`);
+    logger.notice(`Posting the review failed: ${message}`);
   }
 }
 
@@ -49,6 +49,6 @@ export async function postNothingAnalyzedReview(message: string): Promise<void> 
     logger.info('Posted review for this pull request.');
   } catch (error: unknown) {
     const message = handleOctokitError(error);
-    logger.error(`Posting the review failed: ${message}`);
+    logger.notice(`Posting the review failed: ${message}`);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,8 @@ main().catch((error: unknown) => {
 
 // exported for testing purposes
 export async function main(): Promise<void> {
+  logger.info(`Running action on event: ${githubConfig.eventName}`);
+
   configure();
 
   await meetsPrerequisites();
@@ -108,7 +110,12 @@ async function analyze(changedFiles: ChangedFiles): Promise<Analysis> {
   const analysis = await runTicsAnalyzer(changedFiles.path);
 
   if (analysis.explorerUrls.length === 0) {
-    deletePreviousComments(await getPostedComments());
+    const previousComments = await getPostedComments();
+
+    if (previousComments.length > 0) {
+      await deletePreviousComments(previousComments);
+    }
+
     if (!analysis.completed) {
       actionFailed = 'Failed to run TICS Github Action.';
       await postErrorComment(analysis);
@@ -144,10 +151,12 @@ async function processAnalysis(analysis: Analysis, changedFiles: ChangedFiles) {
 
   let reviewBody = createSummaryBody(analysisResults);
 
-  // If not run on a pull request no comments have to be deleted
-  // and there is no conversation to post to.
+  // If not run on a pull request no comments have to be deleted and there is no conversation to post to.
   if (githubConfig.eventName === 'pull_request') {
-    deletePreviousComments(await getPostedComments());
+    const postedComments = await getPostedComments();
+    if (postedComments.length > 0) {
+      await deletePreviousComments(postedComments);
+    }
 
     await postToConversation(true, reviewBody, analysisResults.passed ? Events.APPROVE : Events.REQUEST_CHANGES);
   }

--- a/test/unit/github/annotations.test.ts
+++ b/test/unit/github/annotations.test.ts
@@ -26,8 +26,9 @@ describe('getPostedReviewComments', () => {
     expect((response as any[]).length).toEqual(3);
   });
 
-  test('Should throw an error on getPostedReviewComments', async () => {
-    const spy = jest.spyOn(logger, 'error');
+  test('Should post a notice when getPostedReviewComments fails', async () => {
+    const spy = jest.spyOn(logger, 'notice');
+
     (octokit.paginate as any).mockImplementationOnce(() => {
       throw new Error();
     });
@@ -58,8 +59,8 @@ describe('deletePreviousReviewComments', () => {
     expect(spy).toHaveBeenCalledTimes(0);
   });
 
-  test('Should throw an error on deletePreviousReviewComments', async () => {
-    const spy = jest.spyOn(logger, 'error');
+  test('Should post a notice when deletePreviousReviewComments fails', async () => {
+    const spy = jest.spyOn(logger, 'notice');
 
     (octokit.rest.pulls.deleteReviewComment as any).mockImplementationOnce(() => {
       throw new Error();

--- a/test/unit/github/comments.test.ts
+++ b/test/unit/github/comments.test.ts
@@ -33,8 +33,8 @@ describe('getPostedReviewComments', () => {
     expect((response as any[]).length).toEqual(3);
   });
 
-  test('Should throw an error on getPostedReviewComments', async () => {
-    const spy = jest.spyOn(logger, 'error');
+  test('Should post a notice on getPostedReviewComments', async () => {
+    const spy = jest.spyOn(logger, 'notice');
     (octokit.paginate as any).mockImplementationOnce(() => {
       throw new Error();
     });
@@ -78,12 +78,12 @@ describe('postErrorComment', () => {
     expect(spy).toHaveBeenCalledWith(calledWith);
   });
 
-  test('Should throw an error on postErrorComment', async () => {
+  test('Should post a notice on postErrorComment', async () => {
     (createErrorSummary as any).mockReturnValueOnce('body');
     jest.spyOn(octokit.rest.issues, 'createComment').mockImplementationOnce(() => {
       throw new Error();
     });
-    const spy = jest.spyOn(logger, 'error');
+    const spy = jest.spyOn(logger, 'notice');
 
     const analysis = {
       completed: false,
@@ -138,12 +138,12 @@ describe('deletePreviousComments', () => {
     expect(spy).toHaveBeenCalledTimes(0);
   });
 
-  test('Should throw an error on postErrorComment', async () => {
+  test('Should post a notice on postErrorComment', async () => {
     (createErrorSummary as any).mockReturnValueOnce('body');
     jest.spyOn(octokit.rest.issues, 'deleteComment').mockImplementationOnce(() => {
       throw new Error();
     });
-    const spy = jest.spyOn(logger, 'error');
+    const spy = jest.spyOn(logger, 'notice');
 
     deletePreviousComments([commentWithBody]);
 

--- a/test/unit/github/review.test.ts
+++ b/test/unit/github/review.test.ts
@@ -129,13 +129,13 @@ describe('postReview', () => {
     expect(spy).toHaveBeenCalledWith(calledWith);
   });
 
-  test('Should throw an error on createReview', async () => {
+  test('Should post a notice on createReview', async () => {
     (createSummaryBody as any).mockReturnValueOnce('ReviewBody...');
 
     jest.spyOn(octokit.rest.pulls, 'createReview').mockImplementationOnce(() => {
       throw new Error();
     });
-    const spy = jest.spyOn(logger, 'error');
+    const spy = jest.spyOn(logger, 'notice');
 
     const analysisResults: AnalysisResults = {
       passed: false,
@@ -191,11 +191,11 @@ describe('postNothingAnalyzedReview', () => {
     expect(spy).toHaveBeenCalledWith(calledWith);
   });
 
-  test('Should throw an error on createReview', async () => {
+  test('Should post a notice on createReview', async () => {
     jest.spyOn(octokit.rest.pulls, 'createReview').mockImplementationOnce(() => {
       throw new Error();
     });
-    const spy = jest.spyOn(logger, 'error');
+    const spy = jest.spyOn(logger, 'notice');
 
     await postNothingAnalyzedReview('message');
 


### PR DESCRIPTION
There are a couple of cases where an error occurs without the action failing but an error is given in the output. This might have been a bit too strong, so changed it too notices. Also added logging the event on which an action runs.