### PR TITLE
Fixed bugs with project auto failing and QServer not installing (#34375, #34376)

### DIFF
--- a/src/analysis/client/analysis-results.ts
+++ b/src/analysis/client/analysis-results.ts
@@ -2,7 +2,7 @@ import { createReviewComments } from '../../action/decorate/summary';
 import { actionConfig } from '../../configuration/config';
 import { ChangedFile } from '../../github/interfaces';
 import { AnalysisResult, ProjectResult } from '../../helper/interfaces';
-import { getItemFromUrl, getProjectName } from '../../tics/url';
+import { getItemFromUrl, getProjectFromUrl } from '../../tics/url';
 import { getAnalyzedFiles, getAnalyzedFilesUrl } from '../../viewer/analyzed-files';
 import { getAnnotations } from '../../viewer/annotations';
 import { getQualityGate, getQualityGateUrl } from '../../viewer/qualitygate';
@@ -24,14 +24,15 @@ export async function getClientAnalysisResults(explorerUrls: string[], changedFi
 
   for (const url of explorerUrls) {
     const cdtoken = getItemFromUrl(url, 'ClientData');
+    const project = getProjectFromUrl(url);
 
     const projectResult: ProjectResult = {
-      project: getProjectName(url),
+      project: project,
       explorerUrl: url,
-      analyzedFiles: await getAnalyzedFiles(getAnalyzedFilesUrl({ cdtoken }))
+      analyzedFiles: await getAnalyzedFiles(getAnalyzedFilesUrl(project, { cdtoken }))
     };
 
-    const qualityGate = await getQualityGate(getQualityGateUrl({ cdtoken }));
+    const qualityGate = await getQualityGate(getQualityGateUrl(project, { cdtoken }));
 
     projectResult.qualityGate = qualityGate;
 

--- a/src/analysis/qserver/analysis-result.ts
+++ b/src/analysis/qserver/analysis-result.ts
@@ -8,8 +8,8 @@ import { getQualityGate, getQualityGateUrl } from '../../viewer/qualitygate';
 import { getChangedFiles } from '../helper/changed-files';
 
 export async function getAnalysisResult(date: number): Promise<AnalysisResult> {
-  const qualityGate = await getQualityGate(getQualityGateUrl({ date }));
-  const analyzedFiles = await getAnalyzedFiles(getAnalyzedFilesUrl({ date }));
+  const qualityGate = await getQualityGate(getQualityGateUrl(ticsCli.project, { date }));
+  const analyzedFiles = await getAnalyzedFiles(getAnalyzedFilesUrl(ticsCli.project, { date }));
 
   let reviewComments: TicsReviewComments | undefined;
   if (actionConfig.postAnnotations) {

--- a/src/configuration/tics.ts
+++ b/src/configuration/tics.ts
@@ -155,7 +155,11 @@ export class TicsConfiguration {
    */
   private setVariables() {
     // variable set to replace the loading bar with synchronising... in the install script
-    exportVariable('TICSIDE', 'GITHUB');
+    exportVariable('TICSCI', 1);
+
+    if (this.mode === Mode.CLIENT || this.mode === Mode.DIAGNOSTIC) {
+      exportVariable('TICSIDE', 'GITHUB');
+    }
 
     // set ticsAuthToken
     if (this.ticsAuthToken) {

--- a/src/tics/url.ts
+++ b/src/tics/url.ts
@@ -25,6 +25,6 @@ export function getItemFromUrl(url: string, query: string): string {
  * @param url the TICS explorer url.
  * @returns project name.
  */
-export function getProjectName(url: string): string {
+export function getProjectFromUrl(url: string): string {
   return ticsCli.project === 'auto' ? getItemFromUrl(url, 'Project') : ticsCli.project;
 }

--- a/src/viewer/analyzed-files.ts
+++ b/src/viewer/analyzed-files.ts
@@ -37,10 +37,10 @@ export async function getAnalyzedFiles(url: string): Promise<string[]> {
  * @param cdtoken (only on client) the cdtoken of the last Client run.
  * @returns The url to get the quality gate analysis.
  */
-export function getAnalyzedFilesUrl({ date, cdtoken }: { date?: number; cdtoken?: string }): string {
+export function getAnalyzedFilesUrl(project: string, { date, cdtoken }: { date?: number; cdtoken?: string }): string {
   const getAnalyzedFilesUrl = new URL(joinUrl(ticsConfig.baseUrl, '/api/public/v1/Measure?metrics=filePath'));
 
-  const filters = [`Project(${ticsCli.project})`];
+  const filters = [`Project(${project})`];
 
   if (ticsCli.branchname) {
     filters.push(`Branch(${ticsCli.branchname})`);

--- a/src/viewer/qualitygate.ts
+++ b/src/viewer/qualitygate.ts
@@ -33,10 +33,10 @@ export async function getQualityGate(url: string): Promise<QualityGate> {
  * @param cdtoken (only on client) the cdtoken of the last Client run.
  * @returns The url to get the quality gate analysis.
  */
-export function getQualityGateUrl({ date, cdtoken }: { date?: number; cdtoken?: string }): string {
+export function getQualityGateUrl(project: string, { date, cdtoken }: { date?: number; cdtoken?: string }): string {
   const qualityGateUrl = new URL(joinUrl(ticsConfig.baseUrl, '/api/public/v1/QualityGateStatus'));
 
-  qualityGateUrl.searchParams.append('project', ticsCli.project);
+  qualityGateUrl.searchParams.append('project', project);
 
   if (ticsCli.branchname) {
     qualityGateUrl.searchParams.append('branch', ticsCli.branchname);

--- a/test/unit/configuration/tics.test.ts
+++ b/test/unit/configuration/tics.test.ts
@@ -375,7 +375,7 @@ describe('TICS Configuration', () => {
     });
   });
 
-  test('Should set every value correctly and set the variables', () => {
+  test('Should set every value correctly and set the variables (Client)', () => {
     const exportSpy = jest.spyOn(core, 'exportVariable');
 
     values = {
@@ -404,8 +404,46 @@ describe('TICS Configuration', () => {
       baseUrl: 'http://localhost/tiobeweb/TICS',
       displayUrl: 'http://viewer.url/'
     });
-    expect(exportSpy).toHaveBeenCalledTimes(6);
+    expect(exportSpy).toHaveBeenCalledTimes(7);
+    expect(exportSpy).toHaveBeenCalledWith('TICSCI', 1);
     expect(exportSpy).toHaveBeenCalledWith('TICSIDE', 'GITHUB');
+    expect(exportSpy).toHaveBeenCalledWith('TICSAUTHTOKEN', 'auth-token');
+    expect(exportSpy).toHaveBeenCalledWith('TICSHOSTNAMEVERIFICATION', false);
+    expect(exportSpy).toHaveBeenCalledWith('TICSTRUSTSTRATEGY', 'self-signed');
+    expect(exportSpy).toHaveBeenCalledWith('NODE_TLS_REJECT_UNAUTHORIZED', 0);
+  });
+
+  test('Should set every value correctly and set the variables (QServer)', () => {
+    const exportSpy = jest.spyOn(core, 'exportVariable');
+
+    values = {
+      filelist: './filelist',
+      githubToken: 'github-token',
+      hostnameVerification: 'false',
+      installTics: 'true',
+      mode: 'qserver',
+      ticsAuthToken: 'auth-token',
+      viewerUrl: 'http://localhost/tiobeweb/TICS/api/cfg?name=default',
+      trustStrategy: 'self-signed',
+      displayUrl: 'http://viewer.url'
+    };
+
+    const ticsConfig = new TicsConfiguration();
+
+    expect(ticsConfig).toMatchObject({
+      filelist: './filelist',
+      githubToken: 'github-token',
+      hostnameVerification: false,
+      installTics: true,
+      mode: Mode.QSERVER,
+      ticsAuthToken: 'auth-token',
+      viewerUrl: 'http://localhost/tiobeweb/TICS/api/cfg?name=default',
+      trustStrategy: TrustStrategy.SELFSIGNED,
+      baseUrl: 'http://localhost/tiobeweb/TICS',
+      displayUrl: 'http://viewer.url/'
+    });
+    expect(exportSpy).toHaveBeenCalledTimes(6);
+    expect(exportSpy).toHaveBeenCalledWith('TICSCI', 1);
     expect(exportSpy).toHaveBeenCalledWith('TICSAUTHTOKEN', 'auth-token');
     expect(exportSpy).toHaveBeenCalledWith('TICSHOSTNAMEVERIFICATION', false);
     expect(exportSpy).toHaveBeenCalledWith('TICSTRUSTSTRATEGY', 'self-signed');

--- a/test/unit/tics/url.test.ts
+++ b/test/unit/tics/url.test.ts
@@ -1,4 +1,4 @@
-import { getItemFromUrl, getProjectName } from '../../../src/tics/url';
+import { getItemFromUrl, getProjectFromUrl } from '../../../src/tics/url';
 import { ticsCliMock } from '../../.setup/mock';
 
 describe('getItemFromUrl', () => {
@@ -17,14 +17,14 @@ describe('getProjectName', () => {
   test('Should return project name from url if project auto', async () => {
     ticsCliMock.project = 'auto';
 
-    const project = getProjectName('https://test.com/Project%28project%29');
+    const project = getProjectFromUrl('https://test.com/Project%28project%29');
     expect(project).toEqual('project');
   });
 
   test('Should return default project name from url if project is given', async () => {
     ticsCliMock.project = 'project';
 
-    const project = getProjectName('https://test.com/Project%28auto%29');
+    const project = getProjectFromUrl('https://test.com/Project%28auto%29');
     expect(project).toEqual(ticsCliMock.project);
   });
 });

--- a/test/unit/viewer/analyzed-file.test.ts
+++ b/test/unit/viewer/analyzed-file.test.ts
@@ -51,7 +51,7 @@ describe('getAnalyzedFilesUrl', () => {
   test('Should return url containing date if given', async () => {
     ticsCliMock.branchname = 'branch';
 
-    const url = getAnalyzedFilesUrl({ date: 1714577689 });
+    const url = getAnalyzedFilesUrl('project', { date: 1714577689 });
 
     expect(url).toEqual(
       'http://viewer.url/api/public/v1/Measure?metrics=filePath&filters=Project%28project%29%2CBranch%28branch%29%2CDate%281714577689%29%2CCodeType%28Set%28production%2Ctest%2Cexternal%2Cgenerated%29%29%2CWindow%28-1%29%2CFile%28%29'
@@ -61,7 +61,7 @@ describe('getAnalyzedFilesUrl', () => {
   test('Should return url containing cdtoken if given', async () => {
     ticsCliMock.branchname = '';
 
-    const url = getAnalyzedFilesUrl({ cdtoken: '1714577689' });
+    const url = getAnalyzedFilesUrl('project', { cdtoken: '1714577689' });
 
     expect(url).toEqual(
       'http://viewer.url/api/public/v1/Measure?metrics=filePath&filters=Project%28project%29%2CClientData%281714577689%29%2CCodeType%28Set%28production%2Ctest%2Cexternal%2Cgenerated%29%29%2CWindow%28-1%29%2CFile%28%29'
@@ -69,7 +69,7 @@ describe('getAnalyzedFilesUrl', () => {
   });
 
   test('Should return url containing both if both are given', async () => {
-    const url = getAnalyzedFilesUrl({ date: 1714577689, cdtoken: '1714577689' });
+    const url = getAnalyzedFilesUrl('project', { date: 1714577689, cdtoken: '1714577689' });
 
     expect(url).toEqual(
       'http://viewer.url/api/public/v1/Measure?metrics=filePath&filters=Project%28project%29%2CDate%281714577689%29%2CClientData%281714577689%29%2CCodeType%28Set%28production%2Ctest%2Cexternal%2Cgenerated%29%29%2CWindow%28-1%29%2CFile%28%29'
@@ -77,7 +77,7 @@ describe('getAnalyzedFilesUrl', () => {
   });
 
   test('Should return url containing none if none are given', async () => {
-    const url = getAnalyzedFilesUrl({});
+    const url = getAnalyzedFilesUrl('project', {});
 
     expect(url).toEqual(
       'http://viewer.url/api/public/v1/Measure?metrics=filePath&filters=Project%28project%29%2CCodeType%28Set%28production%2Ctest%2Cexternal%2Cgenerated%29%29%2CWindow%28-1%29%2CFile%28%29'

--- a/test/unit/viewer/qualitygate.test.ts
+++ b/test/unit/viewer/qualitygate.test.ts
@@ -30,10 +30,10 @@ describe('getQualityGateUrl', () => {
     ticsConfigMock.baseUrl = 'http://viewer.url';
     ticsCliMock.branchname = 'branch';
 
-    const url = getQualityGateUrl({ date: 1714577689 });
+    const url = getQualityGateUrl('project', { date: 1714577689 });
 
     expect(url).toEqual(
-      'http://viewer.url/api/public/v1/QualityGateStatus?project=&branch=branch&fields=details%2CannotationsApiV1Links&includeFields=blockingAfter&date=1714577689'
+      'http://viewer.url/api/public/v1/QualityGateStatus?project=project&branch=branch&fields=details%2CannotationsApiV1Links&includeFields=blockingAfter&date=1714577689'
     );
   });
 
@@ -41,30 +41,30 @@ describe('getQualityGateUrl', () => {
     ticsConfigMock.baseUrl = 'http://viewer.url';
     ticsCliMock.branchname = '';
 
-    const url = getQualityGateUrl({ cdtoken: '1714577689' });
+    const url = getQualityGateUrl('project', { cdtoken: '1714577689' });
 
     expect(url).toEqual(
-      'http://viewer.url/api/public/v1/QualityGateStatus?project=&fields=details%2CannotationsApiV1Links&includeFields=blockingAfter&cdt=1714577689'
+      'http://viewer.url/api/public/v1/QualityGateStatus?project=project&fields=details%2CannotationsApiV1Links&includeFields=blockingAfter&cdt=1714577689'
     );
   });
 
   test('Should return url containing both if both are given', async () => {
     ticsConfigMock.baseUrl = 'http://viewer.url';
 
-    const url = getQualityGateUrl({ date: 1714577689, cdtoken: '1714577689' });
+    const url = getQualityGateUrl('project', { date: 1714577689, cdtoken: '1714577689' });
 
     expect(url).toEqual(
-      'http://viewer.url/api/public/v1/QualityGateStatus?project=&fields=details%2CannotationsApiV1Links&includeFields=blockingAfter&date=1714577689&cdt=1714577689'
+      'http://viewer.url/api/public/v1/QualityGateStatus?project=project&fields=details%2CannotationsApiV1Links&includeFields=blockingAfter&date=1714577689&cdt=1714577689'
     );
   });
 
   test('Should return url containing none if none are given', async () => {
     ticsConfigMock.baseUrl = 'http://viewer.url';
 
-    const url = getQualityGateUrl({});
+    const url = getQualityGateUrl('project', {});
 
     expect(url).toEqual(
-      'http://viewer.url/api/public/v1/QualityGateStatus?project=&fields=details%2CannotationsApiV1Links&includeFields=blockingAfter'
+      'http://viewer.url/api/public/v1/QualityGateStatus?project=project&fields=details%2CannotationsApiV1Links&includeFields=blockingAfter'
     );
   });
 });


### PR DESCRIPTION
* When retrieving analyzed files and quality gates for Client runs, it used project "auto" to get the data.
* Only setting the TICSIDE variable when running Client or Diagnostic now, as it prevents TICSQServer install.