### PR TITLE
Added job name to the tmp folder (#34604)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3837,6 +3837,21 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -5071,12 +5086,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/src/configuration/github.ts
+++ b/src/configuration/github.ts
@@ -22,12 +22,12 @@ export class GithubConfig {
     this.commitSha = context.sha;
     this.event = this.getGithubEvent();
     this.job = context.job;
-    this.action = context.action;
+    this.action = context.action.replace('__tiobe_', '');
 
     /**
      * Construct the id to use for storing tmpdirs. The action name will
      * be appended with a number if there are multiple runs within a job.
-     * Example: 10897710852_2_TICSQServer__tiobe_tics-github-action_2
+     * Example: 10897710852_2_TICSQServer_tics-github-action_2
      *
      * According to the documentation:
      * If you use the same script or action more than once in the same job, the name will
@@ -35,7 +35,7 @@ export class GithubConfig {
      * https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables
      */
     const runAttempt = process.env.GITHUB_RUN_ATTEMPT ?? '0';
-    this.id = `${context.runId.toString()}_${runAttempt}_${this.job}${this.action}`;
+    this.id = `${context.runId.toString()}_${runAttempt}_${this.job}_${this.action}`;
     this.pullRequestNumber = this.getPullRequestNumber();
     this.debugger = isDebug();
 

--- a/src/configuration/github.ts
+++ b/src/configuration/github.ts
@@ -2,6 +2,7 @@ import { isDebug } from '@actions/core';
 import { context } from '@actions/github';
 import { logger } from '../helper/logger';
 import { GithubEvent } from './github-event';
+import { generateUuid } from '../helper/utils';
 
 export class GithubConfig {
   readonly apiUrl: string;
@@ -21,7 +22,7 @@ export class GithubConfig {
     this.commitSha = context.sha;
     this.event = this.getGithubEvent();
     this.job = context.job;
-    this.id = `${context.runId.toString()}-${this.job}-${context.runNumber.toString()}`;
+    this.id = `${context.runId.toString()}_${this.job}_${context.runNumber.toString()}_${generateUuid().toString()}`;
     this.pullRequestNumber = this.getPullRequestNumber();
     this.debugger = isDebug();
 

--- a/src/configuration/github.ts
+++ b/src/configuration/github.ts
@@ -9,6 +9,7 @@ export class GithubConfig {
   readonly reponame: string;
   readonly commitSha: string;
   readonly event: GithubEvent;
+  readonly job: string;
   readonly id: string;
   readonly pullRequestNumber: number | undefined;
   readonly debugger: boolean;
@@ -19,7 +20,8 @@ export class GithubConfig {
     this.reponame = context.repo.repo;
     this.commitSha = context.sha;
     this.event = this.getGithubEvent();
-    this.id = `${context.runId.toString()}-${context.runNumber.toString()}`;
+    this.job = context.job;
+    this.id = `${context.runId.toString()}-${this.job}-${context.runNumber.toString()}`;
     this.pullRequestNumber = this.getPullRequestNumber();
     this.debugger = isDebug();
 

--- a/src/github/artifacts.ts
+++ b/src/github/artifacts.ts
@@ -15,7 +15,7 @@ export async function uploadArtifact(): Promise<void> {
     logger.header('Uploading artifact');
     const tmpdir = getTmpDir() + '/ticstmpdir';
     logger.info(`Logs gotten from ${tmpdir}`);
-    const response = await artifactClient.uploadArtifact(`${githubConfig.job}-ticstmpdir`, getFilesInFolder(tmpdir), tmpdir);
+    const response = await artifactClient.uploadArtifact(`${githubConfig.job}${githubConfig.action}_ticstmpdir`, getFilesInFolder(tmpdir), tmpdir);
 
     if (response.failedItems.length > 0) {
       logger.debug(`Failed to upload file(s): ${response.failedItems.join(', ')}`);

--- a/src/github/artifacts.ts
+++ b/src/github/artifacts.ts
@@ -6,7 +6,7 @@ import { join } from 'canonical-path';
 
 import { logger } from '../helper/logger';
 import { handleOctokitError } from '../helper/response';
-import { githubConfig, ticsCli } from '../configuration/config';
+import { githubConfig, ticsCli, ticsConfig } from '../configuration/config';
 
 export async function uploadArtifact(): Promise<void> {
   const artifactClient = create();
@@ -15,7 +15,12 @@ export async function uploadArtifact(): Promise<void> {
     logger.header('Uploading artifact');
     const tmpdir = getTmpDir() + '/ticstmpdir';
     logger.info(`Logs gotten from ${tmpdir}`);
-    const response = await artifactClient.uploadArtifact(`${githubConfig.job}${githubConfig.action}_ticstmpdir`, getFilesInFolder(tmpdir), tmpdir);
+    const response = await artifactClient.uploadArtifact(
+      // Example TICS_tics-github-action_2_qserver_ticstmpdir
+      `${githubConfig.job}_${githubConfig.action}_${ticsConfig.mode}_ticstmpdir`,
+      getFilesInFolder(tmpdir),
+      tmpdir
+    );
 
     if (response.failedItems.length > 0) {
       logger.debug(`Failed to upload file(s): ${response.failedItems.join(', ')}`);

--- a/src/github/artifacts.ts
+++ b/src/github/artifacts.ts
@@ -15,7 +15,7 @@ export async function uploadArtifact(): Promise<void> {
     logger.header('Uploading artifact');
     const tmpdir = getTmpDir() + '/ticstmpdir';
     logger.info(`Logs gotten from ${tmpdir}`);
-    const response = await artifactClient.uploadArtifact('ticstmpdir', getFilesInFolder(tmpdir), tmpdir);
+    const response = await artifactClient.uploadArtifact(`${githubConfig.job}-ticstmpdir`, getFilesInFolder(tmpdir), tmpdir);
 
     if (response.failedItems.length > 0) {
       logger.debug(`Failed to upload file(s): ${response.failedItems.join(', ')}`);

--- a/src/helper/utils.ts
+++ b/src/helper/utils.ts
@@ -1,5 +1,3 @@
-import { randomUUID, UUID } from 'crypto';
-
 /**
  * Checks if the first value is one of the following ones.
  * Replaces value === arg1 || value === arg2 || ...
@@ -9,12 +7,4 @@ import { randomUUID, UUID } from 'crypto';
  */
 export function isOneOf<T>(value: T, ...args: [T, ...T[]]): boolean {
   return args.includes(value);
-}
-
-/**
- * Wrapper for generating a UUID (for testing).
- * @returns UUID
- */
-export function generateUuid(): UUID {
-  return randomUUID();
 }

--- a/src/helper/utils.ts
+++ b/src/helper/utils.ts
@@ -1,3 +1,5 @@
+import { randomUUID, UUID } from 'crypto';
+
 /**
  * Checks if the first value is one of the following ones.
  * Replaces value === arg1 || value === arg2 || ...
@@ -7,4 +9,12 @@
  */
 export function isOneOf<T>(value: T, ...args: [T, ...T[]]): boolean {
   return args.includes(value);
+}
+
+/**
+ * Wrapper for generating a UUID (for testing).
+ * @returns UUID
+ */
+export function generateUuid(): UUID {
+  return randomUUID();
 }

--- a/src/tics/analyzer.ts
+++ b/src/tics/analyzer.ts
@@ -152,11 +152,6 @@ export function getTicsCommand(fileListPath: string): string {
     command.push(ticsCli.additionalFlags);
   }
 
-  // Add TICS debug flag when in debug mode, if this flag was not already set.
-  if (githubConfig.debugger && !command.includes('-log ')) {
-    command.push('-log 9');
-  }
-
   return command.join(' ');
 }
 

--- a/test/.setup/mock.ts
+++ b/test/.setup/mock.ts
@@ -9,6 +9,7 @@ export const githubConfigMock: {
   commitSha: string;
   event: GithubEvent;
   job: string;
+  action: string;
   id: string;
   pullRequestNumber: number | undefined;
   debugger: boolean;
@@ -19,7 +20,8 @@ export const githubConfigMock: {
   commitSha: 'sha-128',
   event: GithubEvent.PUSH,
   job: 'TICS',
-  id: '123-TICS-1',
+  action: '__tiobe_tics-github-action',
+  id: '123_TICS_1__tiobe_tics-github-action',
   pullRequestNumber: 1,
   debugger: false
 };
@@ -108,6 +110,7 @@ jest.mock('../../src/github/octokit', () => {
 });
 
 export const contextMock: {
+  action: string;
   apiUrl: string;
   repo: {
     repo: string;
@@ -126,6 +129,7 @@ export const contextMock: {
       | undefined;
   };
 } = {
+  action: '__tiobe_tics-github-action',
   apiUrl: 'api.github.com',
   repo: {
     repo: 'tics-github-action',

--- a/test/.setup/mock.ts
+++ b/test/.setup/mock.ts
@@ -20,8 +20,8 @@ export const githubConfigMock: {
   commitSha: 'sha-128',
   event: GithubEvent.PUSH,
   job: 'TICS',
-  action: '__tiobe_tics-github-action',
-  id: '123_TICS_1__tiobe_tics-github-action',
+  action: 'tics-github-action',
+  id: '123_TICS_1_tics-github-action',
   pullRequestNumber: 1,
   debugger: false
 };
@@ -129,7 +129,7 @@ export const contextMock: {
       | undefined;
   };
 } = {
-  action: '__tiobe_tics-github-action',
+  action: 'tics-github-action',
   apiUrl: 'api.github.com',
   repo: {
     repo: 'tics-github-action',

--- a/test/.setup/mock.ts
+++ b/test/.setup/mock.ts
@@ -8,6 +8,7 @@ export const githubConfigMock: {
   reponame: string;
   commitSha: string;
   event: GithubEvent;
+  job: string;
   id: string;
   pullRequestNumber: number | undefined;
   debugger: boolean;
@@ -17,7 +18,8 @@ export const githubConfigMock: {
   reponame: 'test',
   commitSha: 'sha-128',
   event: GithubEvent.PUSH,
-  id: '123-1',
+  job: 'TICS',
+  id: '123-TICS-1',
   pullRequestNumber: 1,
   debugger: false
 };
@@ -113,6 +115,7 @@ export const contextMock: {
   };
   sha: string;
   eventName: string;
+  job: string;
   runId: number;
   runNumber: number;
   payload: {
@@ -130,6 +133,7 @@ export const contextMock: {
   },
   sha: 'sha-128',
   eventName: 'pull_request',
+  job: 'TICS',
   runId: 123,
   runNumber: 1,
   payload: {

--- a/test/integration/configuration.test.ts
+++ b/test/integration/configuration.test.ts
@@ -21,6 +21,7 @@ describe('pullRequestNumber', () => {
     jest.mock('@actions/github', () => {
       return {
         context: {
+          action: '_tics-github-action',
           payload: {
             pull_request: { number: 1 }
           },
@@ -45,6 +46,7 @@ describe('pullRequestNumber', () => {
     jest.mock('@actions/github', () => {
       return {
         context: {
+          action: '_tics-github-action',
           payload: {
             pull_request: undefined
           },
@@ -71,6 +73,7 @@ describe('pullRequestNumber', () => {
     jest.mock('@actions/github', () => {
       return {
         context: {
+          action: '_tics-github-action',
           payload: {
             pull_request: undefined
           },

--- a/test/integration/httpclient.test.ts
+++ b/test/integration/httpclient.test.ts
@@ -9,6 +9,7 @@ process.env['http_proxy'] = proxyUrl;
 
 // set required inputs
 process.env.GITHUB_REPOSITORY = 'owner/repo';
+process.env.GITHUB_ACTION = '_tics-github-action';
 process.env.INPUT_GITHUBTOKEN = 'token';
 process.env.INPUT_MODE = 'client';
 process.env.INPUT_PROJECTNAME = 'tics-github-action';

--- a/test/integration/octokit.test.ts
+++ b/test/integration/octokit.test.ts
@@ -12,6 +12,7 @@ process.env['http_proxy'] = proxyUrl;
 // set required inputs
 process.env.GITHUB_REPOSITORY = 'owner/repo';
 process.env.GITHUB_API_URL = 'https://api.github.com';
+process.env.GITHUB_ACTION = '_tics-github-action';
 process.env.INPUT_MODE = 'client';
 process.env.INPUT_PROJECTNAME = 'tics-github-action';
 process.env.INPUT_VIEWERURL = 'http://localhost/tiobeweb/TICS/api/cfg?name=default';

--- a/test/unit/configuration/github.test.ts
+++ b/test/unit/configuration/github.test.ts
@@ -1,13 +1,10 @@
 import * as core from '@actions/core';
-import * as utils from '../../../src/helper/utils';
 import { GithubConfig } from '../../../src/configuration/github';
 import { contextMock } from '../../.setup/mock';
-import { randomUUID } from 'crypto';
 
 describe('GitHub Configuration', () => {
   let githubConfig: GithubConfig;
   let debugSpy: jest.SpyInstance;
-  let uuid = randomUUID();
 
   beforeEach(() => {
     debugSpy = jest.spyOn(core, 'isDebug');
@@ -17,8 +14,6 @@ describe('GitHub Configuration', () => {
         return contextMock;
       }
     }));
-
-    jest.spyOn(utils, 'generateUuid').mockReturnValue(uuid);
   });
 
   afterEach(() => {
@@ -26,6 +21,7 @@ describe('GitHub Configuration', () => {
   });
 
   test('Should set variables taken from context', () => {
+    contextMock.action = '__tiobe_tics-github-action';
     contextMock.apiUrl = 'api.github.com';
     contextMock.repo = { repo: 'tics-github-action', owner: 'tiobe' };
     contextMock.sha = 'sha-128';
@@ -35,6 +31,8 @@ describe('GitHub Configuration', () => {
     contextMock.runNumber = 1;
     contextMock.payload = { pull_request: { number: 1 } };
 
+    process.env.GITHUB_RUN_ATTEMPT = '1';
+
     githubConfig = new GithubConfig();
 
     expect(githubConfig).toMatchObject({
@@ -43,7 +41,7 @@ describe('GitHub Configuration', () => {
       reponame: 'tics-github-action',
       commitSha: 'sha-128',
       event: { name: 'pull_request', isPullRequest: true },
-      id: `123_TICS_1_${uuid.toString()}`,
+      id: `123_1_TICS__tiobe_tics-github-action`,
       pullRequestNumber: 1
     });
   });

--- a/test/unit/configuration/github.test.ts
+++ b/test/unit/configuration/github.test.ts
@@ -26,6 +26,7 @@ describe('GitHub Configuration', () => {
     contextMock.sha = 'sha-128';
     contextMock.eventName = 'pull_request';
     contextMock.runId = 123;
+    contextMock.job = 'TICS';
     contextMock.runNumber = 1;
     contextMock.payload = { pull_request: { number: 1 } };
 
@@ -37,7 +38,7 @@ describe('GitHub Configuration', () => {
       reponame: 'tics-github-action',
       commitSha: 'sha-128',
       event: { name: 'pull_request', isPullRequest: true },
-      id: '123-1',
+      id: '123-TICS-1',
       pullRequestNumber: 1
     });
   });

--- a/test/unit/configuration/github.test.ts
+++ b/test/unit/configuration/github.test.ts
@@ -1,12 +1,13 @@
 import * as core from '@actions/core';
+import * as utils from '../../../src/helper/utils';
 import { GithubConfig } from '../../../src/configuration/github';
 import { contextMock } from '../../.setup/mock';
-import * as utils from '../../../src/helper/utils';
+import { randomUUID } from 'crypto';
 
 describe('GitHub Configuration', () => {
   let githubConfig: GithubConfig;
   let debugSpy: jest.SpyInstance;
-  let uuid = crypto.randomUUID();
+  let uuid = randomUUID();
 
   beforeEach(() => {
     debugSpy = jest.spyOn(core, 'isDebug');

--- a/test/unit/configuration/github.test.ts
+++ b/test/unit/configuration/github.test.ts
@@ -1,10 +1,12 @@
 import * as core from '@actions/core';
 import { GithubConfig } from '../../../src/configuration/github';
 import { contextMock } from '../../.setup/mock';
+import * as utils from '../../../src/helper/utils';
 
 describe('GitHub Configuration', () => {
   let githubConfig: GithubConfig;
   let debugSpy: jest.SpyInstance;
+  let uuid = crypto.randomUUID();
 
   beforeEach(() => {
     debugSpy = jest.spyOn(core, 'isDebug');
@@ -14,6 +16,8 @@ describe('GitHub Configuration', () => {
         return contextMock;
       }
     }));
+
+    jest.spyOn(utils, 'generateUuid').mockReturnValue(uuid);
   });
 
   afterEach(() => {
@@ -38,7 +42,7 @@ describe('GitHub Configuration', () => {
       reponame: 'tics-github-action',
       commitSha: 'sha-128',
       event: { name: 'pull_request', isPullRequest: true },
-      id: '123-TICS-1',
+      id: `123_TICS_1_${uuid.toString()}`,
       pullRequestNumber: 1
     });
   });

--- a/test/unit/configuration/github.test.ts
+++ b/test/unit/configuration/github.test.ts
@@ -21,7 +21,7 @@ describe('GitHub Configuration', () => {
   });
 
   test('Should set variables taken from context', () => {
-    contextMock.action = '__tiobe_tics-github-action';
+    contextMock.action = 'tics-github-action';
     contextMock.apiUrl = 'api.github.com';
     contextMock.repo = { repo: 'tics-github-action', owner: 'tiobe' };
     contextMock.sha = 'sha-128';
@@ -41,7 +41,7 @@ describe('GitHub Configuration', () => {
       reponame: 'tics-github-action',
       commitSha: 'sha-128',
       event: { name: 'pull_request', isPullRequest: true },
-      id: `123_1_TICS__tiobe_tics-github-action`,
+      id: `123_1_TICS_tics-github-action`,
       pullRequestNumber: 1
     });
   });

--- a/test/unit/github/artifacts.test.ts
+++ b/test/unit/github/artifacts.test.ts
@@ -16,14 +16,14 @@ describe('Tempdir test', () => {
     githubConfigMock.debugger = true;
     const tmpdir = getTmpDir();
 
-    expect(tmpdir).toStrictEqual('/tmp/tics/123-TICS-1');
+    expect(tmpdir).toStrictEqual('/tmp/tics/123_TICS_1__tiobe_tics-github-action');
   });
 
   it('Should return empty if variable is set', () => {
     ticsCliMock.tmpdir = 'something/else';
     const tmpdir = getTmpDir();
 
-    expect(tmpdir).toStrictEqual('something/else/123-TICS-1');
+    expect(tmpdir).toStrictEqual('something/else/123_TICS_1__tiobe_tics-github-action');
   });
 });
 
@@ -31,21 +31,27 @@ describe('Artifacts test', () => {
   it('Should upload logfile to tmpdir', async () => {
     ticsCliMock.tmpdir = '/tmp';
 
-    jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123-TICS-1/ticstmpdir/file.log')]);
+    jest
+      .spyOn(fs, 'readdirSync')
+      .mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/file.log')]);
     const mockArtifactClient = new MockArtifactClient([]);
     jest.spyOn(artifact, 'create').mockReturnValue(mockArtifactClient);
     const uploadSpy = jest.spyOn(mockArtifactClient, 'uploadArtifact');
 
     await uploadArtifact();
 
-    expect(uploadSpy).toHaveBeenCalledWith('TICS-ticstmpdir', ['/tmp/123-TICS-1/ticstmpdir/file.log'], '/tmp/123-TICS-1/ticstmpdir');
+    expect(uploadSpy).toHaveBeenCalledWith(
+      'TICS__tiobe_tics-github-action_ticstmpdir',
+      ['/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/file.log'],
+      '/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir'
+    );
   });
 
   it('Should upload logdir to tmpdir', async () => {
     ticsCliMock.tmpdir = '/tmp';
 
-    const direntOne = [new MockDirent(false, 'tics', '/tmp/123-TICS-1/ticstmpdir/tics')];
-    const direntTwo = [new MockDirent(true, 'file.log', '/tmp/123-TICS-1/ticstmpdir/tics/file.log')];
+    const direntOne = [new MockDirent(false, 'tics', '/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/tics')];
+    const direntTwo = [new MockDirent(true, 'file.log', '/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/tics/file.log')];
 
     jest.spyOn(fs, 'readdirSync').mockReturnValueOnce(direntOne);
     jest.spyOn(fs, 'readdirSync').mockReturnValueOnce(direntTwo);
@@ -55,36 +61,52 @@ describe('Artifacts test', () => {
 
     await uploadArtifact();
 
-    expect(uploadSpy).toHaveBeenCalledWith('TICS-ticstmpdir', ['/tmp/123-TICS-1/ticstmpdir/tics/file.log'], '/tmp/123-TICS-1/ticstmpdir');
+    expect(uploadSpy).toHaveBeenCalledWith(
+      'TICS__tiobe_tics-github-action_ticstmpdir',
+      ['/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/tics/file.log'],
+      '/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir'
+    );
   });
 
   it('Should call debug logger on failing to upload logfile', async () => {
     ticsCliMock.tmpdir = '/tmp';
 
-    jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123-TICS-1/ticstmpdir/file.log')]);
-    const mockArtifactClient = new MockArtifactClient(['/tmp/123-TICS-1/ticstmpdir/file.log']);
+    jest
+      .spyOn(fs, 'readdirSync')
+      .mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/file.log')]);
+    const mockArtifactClient = new MockArtifactClient(['/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/file.log']);
     jest.spyOn(artifact, 'create').mockReturnValue(mockArtifactClient);
     const uploadSpy = jest.spyOn(mockArtifactClient, 'uploadArtifact');
     const loggerSpy = jest.spyOn(logger, 'debug');
 
     await uploadArtifact();
 
-    expect(uploadSpy).toHaveBeenCalledWith('TICS-ticstmpdir', ['/tmp/123-TICS-1/ticstmpdir/file.log'], '/tmp/123-TICS-1/ticstmpdir');
-    expect(loggerSpy).toHaveBeenCalledWith(`Failed to upload file(s): /tmp/123-TICS-1/ticstmpdir/file.log`);
+    expect(uploadSpy).toHaveBeenCalledWith(
+      'TICS__tiobe_tics-github-action_ticstmpdir',
+      ['/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/file.log'],
+      '/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir'
+    );
+    expect(loggerSpy).toHaveBeenCalledWith(`Failed to upload file(s): /tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/file.log`);
   });
 
   it('Should call debug logger on upload throwing an error', async () => {
     ticsCliMock.tmpdir = '/tmp';
 
-    jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123-TICS-1/ticstmpdir/file.log')]);
-    const mockArtifactClient = new MockArtifactClient(['/tmp/123-TICS-1/ticstmpdir/file.log']);
+    jest
+      .spyOn(fs, 'readdirSync')
+      .mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123_TICS__tiobe_tics-github-action/ticstmpdir/file.log')]);
+    const mockArtifactClient = new MockArtifactClient(['/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/file.log']);
     jest.spyOn(artifact, 'create').mockReturnValue(mockArtifactClient);
     const uploadSpy = jest.spyOn(mockArtifactClient, 'uploadArtifact').mockRejectedValue(Error('connection issues'));
     const loggerSpy = jest.spyOn(logger, 'debug');
 
     await uploadArtifact();
 
-    expect(uploadSpy).toHaveBeenCalledWith('TICS-ticstmpdir', ['/tmp/123-TICS-1/ticstmpdir/file.log'], '/tmp/123-TICS-1/ticstmpdir');
+    expect(uploadSpy).toHaveBeenCalledWith(
+      'TICS__tiobe_tics-github-action_ticstmpdir',
+      ['/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/file.log'],
+      '/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir'
+    );
     expect(loggerSpy).toHaveBeenCalledWith(`Failed to upload artifact: connection issues`);
   });
 });

--- a/test/unit/github/artifacts.test.ts
+++ b/test/unit/github/artifacts.test.ts
@@ -16,14 +16,14 @@ describe('Tempdir test', () => {
     githubConfigMock.debugger = true;
     const tmpdir = getTmpDir();
 
-    expect(tmpdir).toStrictEqual('/tmp/tics/123_TICS_1__tiobe_tics-github-action');
+    expect(tmpdir).toStrictEqual('/tmp/tics/123_TICS_1_tics-github-action');
   });
 
   it('Should return empty if variable is set', () => {
     ticsCliMock.tmpdir = 'something/else';
     const tmpdir = getTmpDir();
 
-    expect(tmpdir).toStrictEqual('something/else/123_TICS_1__tiobe_tics-github-action');
+    expect(tmpdir).toStrictEqual('something/else/123_TICS_1_tics-github-action');
   });
 });
 
@@ -31,9 +31,7 @@ describe('Artifacts test', () => {
   it('Should upload logfile to tmpdir', async () => {
     ticsCliMock.tmpdir = '/tmp';
 
-    jest
-      .spyOn(fs, 'readdirSync')
-      .mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/file.log')]);
+    jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123_TICS_1_tics-github-action/ticstmpdir/file.log')]);
     const mockArtifactClient = new MockArtifactClient([]);
     jest.spyOn(artifact, 'create').mockReturnValue(mockArtifactClient);
     const uploadSpy = jest.spyOn(mockArtifactClient, 'uploadArtifact');
@@ -41,17 +39,17 @@ describe('Artifacts test', () => {
     await uploadArtifact();
 
     expect(uploadSpy).toHaveBeenCalledWith(
-      'TICS__tiobe_tics-github-action_ticstmpdir',
-      ['/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/file.log'],
-      '/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir'
+      'TICS_tics-github-action_client_ticstmpdir',
+      ['/tmp/123_TICS_1_tics-github-action/ticstmpdir/file.log'],
+      '/tmp/123_TICS_1_tics-github-action/ticstmpdir'
     );
   });
 
   it('Should upload logdir to tmpdir', async () => {
     ticsCliMock.tmpdir = '/tmp';
 
-    const direntOne = [new MockDirent(false, 'tics', '/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/tics')];
-    const direntTwo = [new MockDirent(true, 'file.log', '/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/tics/file.log')];
+    const direntOne = [new MockDirent(false, 'tics', '/tmp/123_TICS_1_tics-github-action/ticstmpdir/tics')];
+    const direntTwo = [new MockDirent(true, 'file.log', '/tmp/123_TICS_1_tics-github-action/ticstmpdir/tics/file.log')];
 
     jest.spyOn(fs, 'readdirSync').mockReturnValueOnce(direntOne);
     jest.spyOn(fs, 'readdirSync').mockReturnValueOnce(direntTwo);
@@ -62,19 +60,17 @@ describe('Artifacts test', () => {
     await uploadArtifact();
 
     expect(uploadSpy).toHaveBeenCalledWith(
-      'TICS__tiobe_tics-github-action_ticstmpdir',
-      ['/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/tics/file.log'],
-      '/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir'
+      'TICS_tics-github-action_client_ticstmpdir',
+      ['/tmp/123_TICS_1_tics-github-action/ticstmpdir/tics/file.log'],
+      '/tmp/123_TICS_1_tics-github-action/ticstmpdir'
     );
   });
 
   it('Should call debug logger on failing to upload logfile', async () => {
     ticsCliMock.tmpdir = '/tmp';
 
-    jest
-      .spyOn(fs, 'readdirSync')
-      .mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/file.log')]);
-    const mockArtifactClient = new MockArtifactClient(['/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/file.log']);
+    jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123_TICS_1_tics-github-action/ticstmpdir/file.log')]);
+    const mockArtifactClient = new MockArtifactClient(['/tmp/123_TICS_1_tics-github-action/ticstmpdir/file.log']);
     jest.spyOn(artifact, 'create').mockReturnValue(mockArtifactClient);
     const uploadSpy = jest.spyOn(mockArtifactClient, 'uploadArtifact');
     const loggerSpy = jest.spyOn(logger, 'debug');
@@ -82,20 +78,18 @@ describe('Artifacts test', () => {
     await uploadArtifact();
 
     expect(uploadSpy).toHaveBeenCalledWith(
-      'TICS__tiobe_tics-github-action_ticstmpdir',
-      ['/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/file.log'],
-      '/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir'
+      'TICS_tics-github-action_client_ticstmpdir',
+      ['/tmp/123_TICS_1_tics-github-action/ticstmpdir/file.log'],
+      '/tmp/123_TICS_1_tics-github-action/ticstmpdir'
     );
-    expect(loggerSpy).toHaveBeenCalledWith(`Failed to upload file(s): /tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/file.log`);
+    expect(loggerSpy).toHaveBeenCalledWith(`Failed to upload file(s): /tmp/123_TICS_1_tics-github-action/ticstmpdir/file.log`);
   });
 
   it('Should call debug logger on upload throwing an error', async () => {
     ticsCliMock.tmpdir = '/tmp';
 
-    jest
-      .spyOn(fs, 'readdirSync')
-      .mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123_TICS__tiobe_tics-github-action/ticstmpdir/file.log')]);
-    const mockArtifactClient = new MockArtifactClient(['/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/file.log']);
+    jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123_TICS_tics-github-action/ticstmpdir/file.log')]);
+    const mockArtifactClient = new MockArtifactClient(['/tmp/123_TICS_1_tics-github-action/ticstmpdir/file.log']);
     jest.spyOn(artifact, 'create').mockReturnValue(mockArtifactClient);
     const uploadSpy = jest.spyOn(mockArtifactClient, 'uploadArtifact').mockRejectedValue(Error('connection issues'));
     const loggerSpy = jest.spyOn(logger, 'debug');
@@ -103,9 +97,9 @@ describe('Artifacts test', () => {
     await uploadArtifact();
 
     expect(uploadSpy).toHaveBeenCalledWith(
-      'TICS__tiobe_tics-github-action_ticstmpdir',
-      ['/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir/file.log'],
-      '/tmp/123_TICS_1__tiobe_tics-github-action/ticstmpdir'
+      'TICS_tics-github-action_client_ticstmpdir',
+      ['/tmp/123_TICS_1_tics-github-action/ticstmpdir/file.log'],
+      '/tmp/123_TICS_1_tics-github-action/ticstmpdir'
     );
     expect(loggerSpy).toHaveBeenCalledWith(`Failed to upload artifact: connection issues`);
   });

--- a/test/unit/github/artifacts.test.ts
+++ b/test/unit/github/artifacts.test.ts
@@ -16,14 +16,14 @@ describe('Tempdir test', () => {
     githubConfigMock.debugger = true;
     const tmpdir = getTmpDir();
 
-    expect(tmpdir).toStrictEqual('/tmp/tics/123-1');
+    expect(tmpdir).toStrictEqual('/tmp/tics/123-TICS-1');
   });
 
   it('Should return empty if variable is set', () => {
     ticsCliMock.tmpdir = 'something/else';
     const tmpdir = getTmpDir();
 
-    expect(tmpdir).toStrictEqual('something/else/123-1');
+    expect(tmpdir).toStrictEqual('something/else/123-TICS-1');
   });
 });
 
@@ -31,21 +31,21 @@ describe('Artifacts test', () => {
   it('Should upload logfile to tmpdir', async () => {
     ticsCliMock.tmpdir = '/tmp';
 
-    jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123-1/ticstmpdir/file.log')]);
+    jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123-TICS-1/ticstmpdir/file.log')]);
     const mockArtifactClient = new MockArtifactClient([]);
     jest.spyOn(artifact, 'create').mockReturnValue(mockArtifactClient);
     const uploadSpy = jest.spyOn(mockArtifactClient, 'uploadArtifact');
 
     await uploadArtifact();
 
-    expect(uploadSpy).toHaveBeenCalledWith('ticstmpdir', ['/tmp/123-1/ticstmpdir/file.log'], '/tmp/123-1/ticstmpdir');
+    expect(uploadSpy).toHaveBeenCalledWith('TICS-ticstmpdir', ['/tmp/123-TICS-1/ticstmpdir/file.log'], '/tmp/123-TICS-1/ticstmpdir');
   });
 
   it('Should upload logdir to tmpdir', async () => {
     ticsCliMock.tmpdir = '/tmp';
 
-    const direntOne = [new MockDirent(false, 'tics', '/tmp/123-1/ticstmpdir/tics')];
-    const direntTwo = [new MockDirent(true, 'file.log', '/tmp/123-1/ticstmpdir/tics/file.log')];
+    const direntOne = [new MockDirent(false, 'tics', '/tmp/123-TICS-1/ticstmpdir/tics')];
+    const direntTwo = [new MockDirent(true, 'file.log', '/tmp/123-TICS-1/ticstmpdir/tics/file.log')];
 
     jest.spyOn(fs, 'readdirSync').mockReturnValueOnce(direntOne);
     jest.spyOn(fs, 'readdirSync').mockReturnValueOnce(direntTwo);
@@ -55,36 +55,36 @@ describe('Artifacts test', () => {
 
     await uploadArtifact();
 
-    expect(uploadSpy).toHaveBeenCalledWith('ticstmpdir', ['/tmp/123-1/ticstmpdir/tics/file.log'], '/tmp/123-1/ticstmpdir');
+    expect(uploadSpy).toHaveBeenCalledWith('TICS-ticstmpdir', ['/tmp/123-TICS-1/ticstmpdir/tics/file.log'], '/tmp/123-TICS-1/ticstmpdir');
   });
 
   it('Should call debug logger on failing to upload logfile', async () => {
     ticsCliMock.tmpdir = '/tmp';
 
-    jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123-1/ticstmpdir/file.log')]);
-    const mockArtifactClient = new MockArtifactClient(['/tmp/123-1/ticstmpdir/file.log']);
+    jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123-TICS-1/ticstmpdir/file.log')]);
+    const mockArtifactClient = new MockArtifactClient(['/tmp/123-TICS-1/ticstmpdir/file.log']);
     jest.spyOn(artifact, 'create').mockReturnValue(mockArtifactClient);
     const uploadSpy = jest.spyOn(mockArtifactClient, 'uploadArtifact');
     const loggerSpy = jest.spyOn(logger, 'debug');
 
     await uploadArtifact();
 
-    expect(uploadSpy).toHaveBeenCalledWith('ticstmpdir', ['/tmp/123-1/ticstmpdir/file.log'], '/tmp/123-1/ticstmpdir');
-    expect(loggerSpy).toHaveBeenCalledWith(`Failed to upload file(s): /tmp/123-1/ticstmpdir/file.log`);
+    expect(uploadSpy).toHaveBeenCalledWith('TICS-ticstmpdir', ['/tmp/123-TICS-1/ticstmpdir/file.log'], '/tmp/123-TICS-1/ticstmpdir');
+    expect(loggerSpy).toHaveBeenCalledWith(`Failed to upload file(s): /tmp/123-TICS-1/ticstmpdir/file.log`);
   });
 
   it('Should call debug logger on upload throwing an error', async () => {
     ticsCliMock.tmpdir = '/tmp';
 
-    jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123-1/ticstmpdir/file.log')]);
-    const mockArtifactClient = new MockArtifactClient(['/tmp/123-1/ticstmpdir/file.log']);
+    jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([new MockDirent(true, 'file.log', '/tmp/123-TICS-1/ticstmpdir/file.log')]);
+    const mockArtifactClient = new MockArtifactClient(['/tmp/123-TICS-1/ticstmpdir/file.log']);
     jest.spyOn(artifact, 'create').mockReturnValue(mockArtifactClient);
     const uploadSpy = jest.spyOn(mockArtifactClient, 'uploadArtifact').mockRejectedValue(Error('connection issues'));
     const loggerSpy = jest.spyOn(logger, 'debug');
 
     await uploadArtifact();
 
-    expect(uploadSpy).toHaveBeenCalledWith('ticstmpdir', ['/tmp/123-1/ticstmpdir/file.log'], '/tmp/123-1/ticstmpdir');
+    expect(uploadSpy).toHaveBeenCalledWith('TICS-ticstmpdir', ['/tmp/123-TICS-1/ticstmpdir/file.log'], '/tmp/123-TICS-1/ticstmpdir');
     expect(loggerSpy).toHaveBeenCalledWith(`Failed to upload artifact: connection issues`);
   });
 });

--- a/test/unit/tics/analyzer.test.ts
+++ b/test/unit/tics/analyzer.test.ts
@@ -102,7 +102,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "/bin/bash -c \"TICS='http://base.com/tiobeweb/TICS/api/cfg?name=default'; TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123-1' -log 9\"",
+      "/bin/bash -c \"TICS='http://base.com/tiobeweb/TICS/api/cfg?name=default'; TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123-TICS-1' -log 9\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -126,7 +126,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "powershell \"$env:TICS='http://base.com/tiobeweb/TICS/api/cfg?name=default'; if ($?) {TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123-1' -log 9}\"",
+      "powershell \"$env:TICS='http://base.com/tiobeweb/TICS/api/cfg?name=default'; if ($?) {TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123-TICS-1' -log 9}\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -154,7 +154,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "/bin/bash -c \"source <(curl --silent --insecure 'http://base.com/tiobeweb/TICS/install-url') && TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123-1' -log 9\"",
+      "/bin/bash -c \"source <(curl --silent --insecure 'http://base.com/tiobeweb/TICS/install-url') && TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123-TICS-1' -log 9\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -181,7 +181,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;  iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123-1' -log 9}\"",
+      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;  iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123-TICS-1' -log 9}\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -215,7 +215,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github '@/path/to/file.txt' -viewer -project 'project' -cdtoken token -codetype TESTCODE -calc CS -nocalc CW -norecalc CD -recalc CY -tmpdir '/home/ubuntu/test/123-1' -log 9}\"",
+      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github '@/path/to/file.txt' -viewer -project 'project' -cdtoken token -codetype TESTCODE -calc CS -nocalc CW -norecalc CD -recalc CY -tmpdir '/home/ubuntu/test/123-TICS-1' -log 9}\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -250,7 +250,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github . -viewer -project 'project' -branchname main -cdtoken token -codetype TESTCODE -calc CS -nocalc CW -norecalc CD -recalc CY -tmpdir '/home/ubuntu/test/123-1' -log 9}\"",
+      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github . -viewer -project 'project' -branchname main -cdtoken token -codetype TESTCODE -calc CS -nocalc CW -norecalc CD -recalc CY -tmpdir '/home/ubuntu/test/123-TICS-1' -log 9}\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -289,7 +289,7 @@ describe('getTicsCommand', () => {
     expect(command).toContain('-codetype TESTCODE');
     expect(command).toContain('-branchname main');
     expect(command).not.toContain('-branchdir .');
-    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123-1'`);
+    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123-TICS-1'`);
     expect(command).toContain('-log 9');
   });
 
@@ -321,7 +321,7 @@ describe('getTicsCommand', () => {
     expect(command).not.toContain('-codetype TESTCODE');
     expect(command).toContain('-branchname main');
     expect(command).toContain('-branchdir .');
-    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123-1'`);
+    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123-TICS-1'`);
     expect(command).toContain('-log 9');
   });
 
@@ -353,7 +353,7 @@ describe('getTicsCommand', () => {
     expect(command).not.toContain('-codetype TESTCODE');
     expect(command).not.toContain('-branchname main');
     expect(command).not.toContain('-branchdir .');
-    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123-1'`);
+    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123-TICS-1'`);
     expect(command).toContain('-log 9');
   });
 });

--- a/test/unit/tics/analyzer.test.ts
+++ b/test/unit/tics/analyzer.test.ts
@@ -102,7 +102,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "/bin/bash -c \"TICS='http://base.com/tiobeweb/TICS/api/cfg?name=default'; TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123-TICS-1' -log 9\"",
+      "/bin/bash -c \"TICS='http://base.com/tiobeweb/TICS/api/cfg?name=default'; TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action' -log 9\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -126,7 +126,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "powershell \"$env:TICS='http://base.com/tiobeweb/TICS/api/cfg?name=default'; if ($?) {TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123-TICS-1' -log 9}\"",
+      "powershell \"$env:TICS='http://base.com/tiobeweb/TICS/api/cfg?name=default'; if ($?) {TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action' -log 9}\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -154,7 +154,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "/bin/bash -c \"source <(curl --silent --insecure 'http://base.com/tiobeweb/TICS/install-url') && TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123-TICS-1' -log 9\"",
+      "/bin/bash -c \"source <(curl --silent --insecure 'http://base.com/tiobeweb/TICS/install-url') && TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action' -log 9\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -181,7 +181,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;  iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123-TICS-1' -log 9}\"",
+      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;  iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action' -log 9}\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -215,7 +215,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github '@/path/to/file.txt' -viewer -project 'project' -cdtoken token -codetype TESTCODE -calc CS -nocalc CW -norecalc CD -recalc CY -tmpdir '/home/ubuntu/test/123-TICS-1' -log 9}\"",
+      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github '@/path/to/file.txt' -viewer -project 'project' -cdtoken token -codetype TESTCODE -calc CS -nocalc CW -norecalc CD -recalc CY -tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action'}\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -250,7 +250,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github . -viewer -project 'project' -branchname main -cdtoken token -codetype TESTCODE -calc CS -nocalc CW -norecalc CD -recalc CY -tmpdir '/home/ubuntu/test/123-TICS-1' -log 9}\"",
+      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github . -viewer -project 'project' -branchname main -cdtoken token -codetype TESTCODE -calc CS -nocalc CW -norecalc CD -recalc CY -tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action'}\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -289,7 +289,7 @@ describe('getTicsCommand', () => {
     expect(command).toContain('-codetype TESTCODE');
     expect(command).toContain('-branchname main');
     expect(command).not.toContain('-branchdir .');
-    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123-TICS-1'`);
+    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action'`);
     expect(command).toContain('-log 9');
   });
 
@@ -321,7 +321,7 @@ describe('getTicsCommand', () => {
     expect(command).not.toContain('-codetype TESTCODE');
     expect(command).toContain('-branchname main');
     expect(command).toContain('-branchdir .');
-    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123-TICS-1'`);
+    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action'`);
     expect(command).toContain('-log 9');
   });
 
@@ -353,7 +353,7 @@ describe('getTicsCommand', () => {
     expect(command).not.toContain('-codetype TESTCODE');
     expect(command).not.toContain('-branchname main');
     expect(command).not.toContain('-branchdir .');
-    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123-TICS-1'`);
+    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action'`);
     expect(command).toContain('-log 9');
   });
 });

--- a/test/unit/tics/analyzer.test.ts
+++ b/test/unit/tics/analyzer.test.ts
@@ -102,7 +102,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "/bin/bash -c \"TICS='http://base.com/tiobeweb/TICS/api/cfg?name=default'; TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action' -log 9\"",
+      "/bin/bash -c \"TICS='http://base.com/tiobeweb/TICS/api/cfg?name=default'; TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123_TICS_1_tics-github-action' -log 9\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -126,7 +126,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "powershell \"$env:TICS='http://base.com/tiobeweb/TICS/api/cfg?name=default'; if ($?) {TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action' -log 9}\"",
+      "powershell \"$env:TICS='http://base.com/tiobeweb/TICS/api/cfg?name=default'; if ($?) {TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123_TICS_1_tics-github-action' -log 9}\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -154,7 +154,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "/bin/bash -c \"source <(curl --silent --insecure 'http://base.com/tiobeweb/TICS/install-url') && TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action' -log 9\"",
+      "/bin/bash -c \"source <(curl --silent --insecure 'http://base.com/tiobeweb/TICS/install-url') && TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123_TICS_1_tics-github-action' -log 9\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -181,7 +181,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;  iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action' -log 9}\"",
+      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;  iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github '@/path/to' -viewer -project 'project' -cdtoken token -calc CS -tmpdir '/home/ubuntu/test/123_TICS_1_tics-github-action' -log 9}\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -215,7 +215,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github '@/path/to/file.txt' -viewer -project 'project' -cdtoken token -codetype TESTCODE -calc CS -nocalc CW -norecalc CD -recalc CY -tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action'}\"",
+      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github '@/path/to/file.txt' -viewer -project 'project' -cdtoken token -codetype TESTCODE -calc CS -nocalc CW -norecalc CD -recalc CY -tmpdir '/home/ubuntu/test/123_TICS_1_tics-github-action'}\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -250,7 +250,7 @@ describe('test multiple types of configuration', () => {
     expect(response.statusCode).toEqual(0);
     expect(response.completed).toEqual(true);
     expect(spy).toHaveBeenCalledWith(
-      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github . -viewer -project 'project' -branchname main -cdtoken token -codetype TESTCODE -calc CS -nocalc CW -norecalc CD -recalc CY -tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action'}\"",
+      "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; iex ((New-Object System.Net.WebClient).DownloadString('http://base.com/tiobeweb/TICS/install-url')); if ($?) {TICS -ide github . -viewer -project 'project' -branchname main -cdtoken token -codetype TESTCODE -calc CS -nocalc CW -norecalc CD -recalc CY -tmpdir '/home/ubuntu/test/123_TICS_1_tics-github-action'}\"",
       [],
       {
         listeners: { stderr: expect.any(Function), stdout: expect.any(Function) },
@@ -289,7 +289,7 @@ describe('getTicsCommand', () => {
     expect(command).toContain('-codetype TESTCODE');
     expect(command).toContain('-branchname main');
     expect(command).not.toContain('-branchdir .');
-    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action'`);
+    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123_TICS_1_tics-github-action'`);
     expect(command).toContain('-log 9');
   });
 
@@ -321,7 +321,7 @@ describe('getTicsCommand', () => {
     expect(command).not.toContain('-codetype TESTCODE');
     expect(command).toContain('-branchname main');
     expect(command).toContain('-branchdir .');
-    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action'`);
+    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123_TICS_1_tics-github-action'`);
     expect(command).toContain('-log 9');
   });
 
@@ -353,7 +353,7 @@ describe('getTicsCommand', () => {
     expect(command).not.toContain('-codetype TESTCODE');
     expect(command).not.toContain('-branchname main');
     expect(command).not.toContain('-branchdir .');
-    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123_TICS_1__tiobe_tics-github-action'`);
+    expect(command).toContain(`-tmpdir '/home/ubuntu/test/123_TICS_1_tics-github-action'`);
     expect(command).toContain('-log 9');
   });
 });


### PR DESCRIPTION
If multiple TICS runs are run within the same workflow, the ticstmpdir would point to the same directory. Fixing that now by adding the job name to the tmp directory. The job name is also added to the artifact name.