### PR TITLE
Read TICS output line by line

### DIFF
--- a/.githooks/pre-commit/run
+++ b/.githooks/pre-commit/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-npm run test

--- a/dist/licenses.txt
+++ b/dist/licenses.txt
@@ -1268,6 +1268,57 @@ Address all questions regarding this license to:
   tjw@cs.Stanford.EDU
 
 
+lodash
+MIT
+Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.
+
+
 lru-cache
 ISC
 The ISC License
@@ -1757,32 +1808,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-
-underscore
-MIT
-Copyright (c) 2009-2022 Jeremy Ashkenas, Julian Gonggrijp, and DocumentCloud and Investigative Reporters & Editors
-
-Permission is hereby granted, free of charge, to any person
-obtaining a copy of this software and associated documentation
-files (the "Software"), to deal in the Software without
-restriction, including without limitation the rights to use,
-copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
 
 
 undici

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,7 @@ export default tseslint.config(
   },
   {
     files: ['src/**/*.ts'],
-    extends: [eslint.configs.strict, ...tseslint.configs.strictTypeChecked, ...tseslint.configs.stylisticTypeChecked, prettier],
+    extends: [eslint.configs.recommended, ...tseslint.configs.strictTypeChecked, ...tseslint.configs.stylisticTypeChecked, prettier],
     languageOptions: {
       parserOptions: {
         projectService: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,18 +20,18 @@
         "canonical-path": "^1.0.0",
         "compare-versions": "^6.1.1",
         "date-fns": "^4.1.0",
+        "lodash": "^4.17.21",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.6.3",
-        "underscore": "^1.13.7"
+        "semver": "^7.6.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.10.0",
         "@jest/globals": "^29.7.0",
         "@types/eslint__js": "^8.42.3",
         "@types/jest": "^29.5.14",
+        "@types/lodash": "^4.17.16",
         "@types/node": "^22.5.5",
         "@types/semver": "^7.5.8",
-        "@types/underscore": "^1.11.15",
         "@vercel/ncc": "^0.38.3",
         "async-listen": "^3.0.1",
         "eslint": "^9.19.0",
@@ -1979,6 +1979,13 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.5.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
@@ -2006,12 +2013,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "node_modules/@types/underscore": {
-      "version": "1.11.15",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.15.tgz",
-      "integrity": "sha512-HP38xE+GuWGlbSRq9WrZkousaQ7dragtZCruBVMi0oX1migFZavZ3OROKHSkNp/9ouq82zrWtZpg18jFnVN96g==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -3620,20 +3621,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -4787,6 +4774,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -5981,11 +5974,6 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.8.0"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="
     },
     "node_modules/undici": {
       "version": "5.28.4",

--- a/package.json
+++ b/package.json
@@ -38,18 +38,18 @@
     "canonical-path": "^1.0.0",
     "compare-versions": "^6.1.1",
     "date-fns": "^4.1.0",
+    "lodash": "^4.17.21",
     "proxy-agent": "^6.5.0",
-    "semver": "^7.6.3",
-    "underscore": "^1.13.7"
+    "semver": "^7.6.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.10.0",
     "@jest/globals": "^29.7.0",
     "@types/eslint__js": "^8.42.3",
     "@types/jest": "^29.5.14",
+    "@types/lodash": "^4.17.16",
     "@types/node": "^22.5.5",
     "@types/semver": "^7.5.8",
-    "@types/underscore": "^1.11.15",
     "@vercel/ncc": "^0.38.3",
     "async-listen": "^3.0.1",
     "eslint": "^9.19.0",

--- a/src/action/decorate/summary.ts
+++ b/src/action/decorate/summary.ts
@@ -1,6 +1,6 @@
 import { EOL } from 'os';
 import { format } from 'date-fns';
-import { range } from 'underscore';
+import { range } from 'lodash';
 import { summary } from '@actions/core';
 import { SummaryTableRow } from '@actions/core/lib/summary';
 import { ChangedFile } from '../../github/interfaces';

--- a/src/action/decorate/summary.ts
+++ b/src/action/decorate/summary.ts
@@ -397,8 +397,8 @@ export function createUnpostableAnnotationsDetails(unpostableReviewComments: Ext
   let previousPath = '';
 
   unpostableReviewComments.forEach(reviewComment => {
-    const path = reviewComment.path ? reviewComment.path : '';
-    const displayCount = reviewComment.displayCount ? reviewComment.displayCount : '';
+    const path = reviewComment.path ?? '';
+    const displayCount = reviewComment.displayCount ?? '';
     const icon = reviewComment.blocking?.state === 'after' ? ':warning:' : ':x:';
     const blocking =
       reviewComment.blocking?.state === 'after' && reviewComment.blocking.after
@@ -414,7 +414,7 @@ export function createUnpostableAnnotationsDetails(unpostableReviewComments: Ext
     body += reviewComment.level ? `<br><b>Level:</b> ${reviewComment.level.toString()}` : '';
     body += reviewComment.category ? `<br><b>Category:</b> ${reviewComment.category}` : '';
     body += `</td><td><b>${reviewComment.type} violation:</b> ${reviewComment.rule ?? ''} <b>${displayCount}</b><br>${reviewComment.msg}</td></tr>`;
-    previousPath = reviewComment.path ? reviewComment.path : '';
+    previousPath = reviewComment.path ?? '';
   });
   body += '</table>';
   return generateExpandableAreaMarkdown(label, body);

--- a/src/helper/logger.ts
+++ b/src/helper/logger.ts
@@ -1,5 +1,6 @@
 import * as core from '@actions/core';
 import { AnnotationProperties } from '@actions/core';
+import { escapeRegExp } from 'lodash';
 
 class Logger {
   called = '';
@@ -133,8 +134,9 @@ class Logger {
 
     // Find secrets value and add them to this.matched
     this.secretsFilter.forEach((secret: string) => {
-      if (data.match(new RegExp(secret, 'gi'))) {
-        const regex = new RegExp(`\\w*${secret}\\w*(?:[ \\t]*[:=>]*[ \\t]*)(.*)`, 'gi');
+      const safeSecret = escapeRegExp(secret);
+      if (data.match(new RegExp(safeSecret, 'gi'))) {
+        const regex = new RegExp(`\\w*${safeSecret}\\w*(?:[ \\t]*[:=>]*[ \\t]*)(.*)`, 'gi');
         let match: RegExpExecArray | null = null;
         while ((match = regex.exec(data))) {
           if (match[1] !== '') {

--- a/src/tics/analyzer.ts
+++ b/src/tics/analyzer.ts
@@ -34,14 +34,14 @@ export async function runTicsAnalyzer(fileListPath: string): Promise<Analysis> {
       listeners: {
         stdline(data: string) {
           const filtered = logger.maskOutput(data);
-          process.stdout.write(filtered ?? '' + EOL);
+          process.stdout.write((filtered ?? '') + EOL);
           if (filtered) {
             findInStdOutOrErr(filtered);
           }
         },
         errline(data: string) {
           const filtered = logger.maskOutput(data);
-          process.stdout.write(filtered ?? '' + EOL);
+          process.stdout.write((filtered ?? '') + EOL);
           if (filtered) {
             findInStdOutOrErr(filtered);
           }

--- a/src/tics/analyzer.ts
+++ b/src/tics/analyzer.ts
@@ -32,15 +32,15 @@ export async function runTicsAnalyzer(fileListPath: string): Promise<Analysis> {
     statusCode = await exec(command, [], {
       silent: true,
       listeners: {
-        stdout(data: Buffer) {
-          const filtered = logger.maskOutput(data.toString());
+        stdline(data: string) {
+          const filtered = logger.maskOutput(data);
           if (filtered) {
             process.stdout.write(filtered);
             findInStdOutOrErr(filtered);
           }
         },
-        stderr(data: Buffer) {
-          const filtered = logger.maskOutput(data.toString());
+        errline(data: string) {
+          const filtered = logger.maskOutput(data);
           if (filtered) {
             process.stdout.write(filtered);
             findInStdOutOrErr(filtered);

--- a/src/tics/analyzer.ts
+++ b/src/tics/analyzer.ts
@@ -34,15 +34,15 @@ export async function runTicsAnalyzer(fileListPath: string): Promise<Analysis> {
       listeners: {
         stdline(data: string) {
           const filtered = logger.maskOutput(data);
+          process.stdout.write(filtered ?? '' + EOL);
           if (filtered) {
-            process.stdout.write(filtered + EOL);
             findInStdOutOrErr(filtered);
           }
         },
         errline(data: string) {
           const filtered = logger.maskOutput(data);
+          process.stdout.write(filtered ?? '' + EOL);
           if (filtered) {
-            process.stdout.write(filtered + EOL);
             findInStdOutOrErr(filtered);
           }
         }

--- a/src/tics/analyzer.ts
+++ b/src/tics/analyzer.ts
@@ -3,7 +3,7 @@ import { logger } from '../helper/logger';
 import { Analysis } from '../helper/interfaces';
 import { getTmpDir } from '../github/artifacts';
 import { InstallTics } from '@tiobe/install-tics';
-import { platform } from 'os';
+import { EOL, platform } from 'os';
 import { isOneOf } from '../helper/utils';
 import { joinUrl } from '../helper/url';
 import { githubConfig, ticsCli, ticsConfig } from '../configuration/config';
@@ -35,14 +35,14 @@ export async function runTicsAnalyzer(fileListPath: string): Promise<Analysis> {
         stdline(data: string) {
           const filtered = logger.maskOutput(data);
           if (filtered) {
-            process.stdout.write(filtered);
+            process.stdout.write(filtered + EOL);
             findInStdOutOrErr(filtered);
           }
         },
         errline(data: string) {
           const filtered = logger.maskOutput(data);
           if (filtered) {
-            process.stdout.write(filtered);
+            process.stdout.write(filtered + EOL);
             findInStdOutOrErr(filtered);
           }
         }

--- a/test/unit/configuration/tics.test.ts
+++ b/test/unit/configuration/tics.test.ts
@@ -20,6 +20,7 @@ describe('tICS Configuration', () => {
   };
 
   beforeEach(() => {
+    process.env = {};
     jest.resetModules();
     jest.spyOn(core, 'getInput').mockImplementation((name): string => {
       for (const value in values) {


### PR DESCRIPTION
See [35937](https://redmine.tiobe.com/issues/35937). 

The buffer of the output streams of the TICS process was read at once. If this buffer contained more than one instance of e.g. explorer URLs, only one was matched, causing incomplete analysis results.

Now using stdline and errline callbacks, which are called for one line at a time.