### PR TITLE
Support GitHub Event Override via Environment Variable

### DIFF
--- a/src/configuration/github.ts
+++ b/src/configuration/github.ts
@@ -61,8 +61,10 @@ export class GithubConfig {
     }
   }
 
-  private getGithubEvent() {
-    switch (context.eventName) {
+  private getGithubEvent(): GithubEvent {
+    const eventName = process.env.GITHUB_EVENT_NAME ?? context.eventName;
+  
+    switch (eventName) {
       case GithubEvent.PULL_REQUEST.name:
         return GithubEvent.PULL_REQUEST;
       case GithubEvent.PULL_REQUEST_TARGET.name:
@@ -79,6 +81,7 @@ export class GithubConfig {
         return GithubEvent.PUSH;
     }
   }
+
 
   getCommentIdentifier(): string {
     return [this.workflow, this.job, this.runNumber, this.runAttempt].join('_');


### PR DESCRIPTION
#### 🛠 Summary
This PR enhances the `GithubConfig` class by allowing the GitHub event type to be overridden using the `GITHUB_EVENT_NAME` environment variable. This is particularly useful for testing workflows or running actions in custom environments where the GitHub context may not be fully available.

#### ✅ Changes
- Updated the `getGithubEvent()` method to:
  - Check for `process.env.GITHUB_EVENT_NAME` first.
  - Fallback to `context.eventName` if the environment variable is not set.
- Maintains backward compatibility with existing behavior.

#### 🔍 Why?
In some scenarios (e.g., local testing, CI/CD simulations), the GitHub Actions context may not reflect the desired event. This change provides flexibility by allowing developers to explicitly set the event type via an environment variable. In my case I want to trigger a workflow in a pull request on a comment change and I want to be able to run the TICS action as if this is triggered as a normal PR trigger. Out solution adds a comment like this to the PR and a click on one of the boxes is seen as a comment edit:
![image](https://github.com/user-attachments/assets/4d5584ff-2867-4c63-9e0d-1f36ec4d1cf1)

