### PR TITLE
RM-38452: Added random string to tmpdir name to make them unique

### DIFF
--- a/src/github/artifacts.ts
+++ b/src/github/artifacts.ts
@@ -9,13 +9,14 @@ import { githubConfig, ticsCli, ticsConfig } from '../configuration/config';
 import { logger } from '../helper/logger';
 import { handleOctokitError } from '../helper/response';
 import { emptyToNull } from '../helper/utils';
+import { randomUUID } from 'crypto';
 
 export async function uploadArtifact(): Promise<void> {
   logger.header('Uploading artifact');
 
   const tmpdir = getTmpDir() + '/ticstmpdir';
   // Example TICS_tics-github-action_2_qserver_ticstmpdir
-  const name = sanitizeArtifactName(`${githubConfig.job}_${githubConfig.action}_${ticsConfig.mode}_ticstmpdir`);
+  const name = sanitizeArtifactName(`${githubConfig.job}_${githubConfig.action}_${ticsConfig.mode}_ticstmpdir_${randomUUID().substring(0, 8)}`);
 
   logger.info(`Logs taken from ${tmpdir}`);
 

--- a/test/unit/github/artifacts.test.ts
+++ b/test/unit/github/artifacts.test.ts
@@ -51,7 +51,7 @@ describe('artifacts test (github.com)', () => {
     await uploadArtifact();
 
     expect(uploadSpy).toHaveBeenCalledWith(
-      'TICS_tics-github-action_client_ticstmpdir',
+      expect.stringContaining('TICS_tics-github-action_client_ticstmpdir'),
       ['/tmp/123_TICS_1_tics-github-action/ticstmpdir/file.log'],
       '/tmp/123_TICS_1_tics-github-action/ticstmpdir'
     );
@@ -71,7 +71,7 @@ describe('artifacts test (github.com)', () => {
     await uploadArtifact();
 
     expect(uploadSpy).toHaveBeenCalledWith(
-      'TICS_tics-github-action_client_ticstmpdir',
+      expect.stringContaining('TICS_tics-github-action_client_ticstmpdir'),
       ['/tmp/123_TICS_1_tics-github-action/ticstmpdir/tics/file.log'],
       '/tmp/123_TICS_1_tics-github-action/ticstmpdir'
     );
@@ -89,7 +89,7 @@ describe('artifacts test (github.com)', () => {
     await uploadArtifact();
 
     expect(uploadSpy).toHaveBeenCalledWith(
-      'TICS_tics-github-action_client_ticstmpdir',
+      expect.stringContaining('TICS_tics-github-action_client_ticstmpdir'),
       ['/tmp/123_TICS_1_tics-github-action/ticstmpdir/file.log'],
       '/tmp/123_TICS_1_tics-github-action/ticstmpdir'
     );
@@ -119,7 +119,7 @@ describe('artifacts test (ghes)', () => {
     await uploadArtifact();
 
     expect(uploadSpy).toHaveBeenCalledWith(
-      'TICS_tics-github-action_client_ticstmpdir',
+      expect.stringContaining('TICS_tics-github-action_client_ticstmpdir'),
       ['/tmp/123_TICS_1_tics-github-action/ticstmpdir/file.log'],
       '/tmp/123_TICS_1_tics-github-action/ticstmpdir'
     );
@@ -138,7 +138,7 @@ describe('artifacts test (ghes)', () => {
     await uploadArtifact();
 
     expect(uploadSpy).toHaveBeenCalledWith(
-      'TICS_tics-github-action_client_ticstmpdir',
+      expect.stringContaining('TICS_tics-github-action_client_ticstmpdir'),
       ['/tmp/123_TICS_1_tics-github-action/ticstmpdir/tics/file.log'],
       '/tmp/123_TICS_1_tics-github-action/ticstmpdir'
     );
@@ -160,7 +160,7 @@ describe('artifacts test (ghes)', () => {
     await uploadArtifact();
 
     expect(uploadSpy).toHaveBeenCalledWith(
-      'TICS_tics-github-action_client_ticstmpdir',
+      expect.stringContaining('TICS_tics-github-action_client_ticstmpdir'),
       ['/tmp/123_TICS_1_tics-github-action/ticstmpdir/file.log'],
       '/tmp/123_TICS_1_tics-github-action/ticstmpdir'
     );
@@ -188,7 +188,7 @@ describe('artifacts test (ghes)', () => {
     await uploadArtifact();
 
     expect(uploadSpy).toHaveBeenCalledWith(
-      'TICS_tics-github-action_client_ticstmpdir',
+      expect.stringContaining('TICS_tics-github-action_client_ticstmpdir'),
       ['/tmp/123_TICS_1_tics-github-action/ticstmpdir/file.log', '/tmp/123_TICS_1_tics-github-action/ticstmpdir/file1.log'],
       '/tmp/123_TICS_1_tics-github-action/ticstmpdir'
     );
@@ -206,7 +206,7 @@ describe('artifacts test (ghes)', () => {
     await uploadArtifact();
 
     expect(uploadSpy).toHaveBeenCalledWith(
-      'TICS_tics-github-action_client_ticstmpdir',
+      expect.stringContaining('TICS_tics-github-action_client_ticstmpdir'),
       ['/tmp/123_TICS_1_tics-github-action/ticstmpdir/file.log'],
       '/tmp/123_TICS_1_tics-github-action/ticstmpdir'
     );


### PR DESCRIPTION
We extended the tmpdir name for uploading in #387, but it still caused collisions.